### PR TITLE
feat: select several items at once, and give notes provenance

### DIFF
--- a/crates/app/src/actions.rs
+++ b/crates/app/src/actions.rs
@@ -67,6 +67,17 @@ pub fn key_bindings() -> Vec<KeyBinding> {
         // Backspace deleting *text* while the cell editor or the find bar holds focus.
         KeyBinding::new("backspace", table::Clear, Some(table::GRID_CONTEXT)),
         KeyBinding::new("delete", table::Clear, Some(table::GRID_CONTEXT)),
+        // Escape drops the selection — what the Details panel used to spend a button on. Scoped to
+        // the three places a selection is visible rather than bound globally: the find bar, the
+        // cell editor, a popup menu and the fullscreen viewer all answer Escape with "close me",
+        // and each of those contexts sits deeper than these, so it keeps that meaning there.
+        KeyBinding::new("escape", table::Deselect, Some(table::GRID_CONTEXT)),
+        KeyBinding::new(
+            "escape",
+            table::Deselect,
+            Some(workspace::DETAILS_META.name),
+        ),
+        KeyBinding::new("escape", table::Deselect, Some(workspace::VIEWS_CONTEXT)),
     ]
     .into_iter()
     // Ctrl+1, Ctrl+2, … pick a view directly, in `ViewMode::ALL` order — so a new view gets its
@@ -98,6 +109,9 @@ pub fn register_global_handlers(cx: &mut App) {
     // de-globalize them per-window first.
     cx.on_action(|_: &NewWindow, _cx| log::warn!("NewWindow: TODO (bar registries are global)"));
     cx.on_action(|_: &Save, cx| table::save_now(cx));
+    // One handler for all three bindings above: which view was showing the selection doesn't
+    // change what dropping it means.
+    cx.on_action(|_: &table::Deselect, cx| table::clear_selection(cx));
     // Edit ▸ Undo/Redo dispatches wherever focus happens to sit, which is not always the grid —
     // globally is the only place that catches it from any panel.
     cx.on_action(|_: &table::Undo, cx| table::history_step(false, cx));

--- a/crates/app/src/status_items/cell_location.rs
+++ b/crates/app/src/status_items/cell_location.rs
@@ -43,6 +43,13 @@ impl CellLocation {
             return "No table".into();
         };
         let state = state.read(cx);
+        // A multi-selection is counted, not located: "Row 7" is the wrong answer once seven rows
+        // are picked, and the count is what the archivist is checking before a bulk edit.
+        let selected = state.delegate().selected_source_rows();
+        if selected.len() > 1 {
+            let total = state.delegate().visible().len();
+            return format!("{} of {total} items selected", selected.len()).into();
+        }
         match state.delegate().selection() {
             Some(Selection::Cell { row, col }) => {
                 let words = state

--- a/crates/diagnostics/src/fixes.rs
+++ b/crates/diagnostics/src/fixes.rs
@@ -122,6 +122,7 @@ mod tests {
                 severity: Severity::Error,
                 source: Source::Validator(source.into()),
                 message: "not a known term".into(),
+                filed: None,
             }],
             cx,
         );
@@ -176,12 +177,14 @@ mod tests {
                     severity: Severity::Error,
                     source: Source::Validator("LCSH".into()),
                     message: "not a known term".into(),
+                    filed: None,
                 },
                 Diagnostic {
                     location: location("Subject"),
                     severity: Severity::Warning,
                     source: Source::Validator("LCSH".into()),
                     message: "also deprecated".into(),
+                    filed: None,
                 },
             ];
             Diagnostics::set(

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -73,7 +73,7 @@ impl Severity {
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum Source {
     /// A note attached to the data, whether typed here or carried in from the imported
-    /// spreadsheet. Notes carry no provenance — one is worth no more than the other. Persists.
+    /// spreadsheet. Persists, and carries whatever provenance it arrived with — see [`Filed`].
     Note,
     /// A named rule, validator, plugin, or language server — the string is what the panel shows.
     /// Never persisted: computed output is recomputed on open, and stored copies go stale.
@@ -100,6 +100,30 @@ pub struct Diagnostic {
     pub severity: Severity,
     pub source: Source,
     pub message: SharedString,
+    /// Who filed this and when, for authored notes. Always `None` on a computed finding — a
+    /// validator's output is recomputed on open, so it has no history to carry.
+    pub filed: Option<Filed>,
+}
+
+/// A note's provenance. Free text rather than a parsed date: a catalogue inherits notes from
+/// whatever kept them before, and refusing to store "March 1998" because it is not ISO-8601 loses
+/// the note to keep the field tidy.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub struct Filed {
+    pub date: Option<SharedString>,
+    pub author: Option<SharedString>,
+}
+
+impl Filed {
+    /// `1998-03-04 · MA`, or whichever half exists. `None` when neither does, so a caller can drop
+    /// the line rather than render an empty one.
+    pub fn label(&self) -> Option<SharedString> {
+        match (self.date.as_ref(), self.author.as_ref()) {
+            (Some(date), Some(author)) => Some(format!("{date} · {author}").into()),
+            (Some(only), None) | (None, Some(only)) => Some(only.clone()),
+            (None, None) => None,
+        }
+    }
 }
 
 /// The palette `panels/log_viewer.rs` used to key off `[ERROR]`/`[WARN]` line prefixes, now
@@ -212,7 +236,9 @@ impl Diagnostics {
         Self::at(dataset, row, column, cx).map(|d| d.severity).min()
     }
 
-    /// The note filed here, if any — what the `Notes ▸` menu offers to edit rather than add.
+    /// The note filed here, if any — what the `Notes ▸` menu offers to edit rather than add. The
+    /// *first* of them: editing is how a single note is corrected, while a second observation
+    /// about the same item is added rather than overwriting the first.
     pub fn note_at(
         dataset: &str,
         row: Option<usize>,
@@ -224,10 +250,75 @@ impl Diagnostics {
             .map(|d| d.message.clone())
     }
 
+    /// Every note filed here, oldest first — what the Notes panel lists. An item accumulates
+    /// observations over decades of cataloguing, and each is somebody's separate act.
+    pub fn notes_at<'a>(
+        dataset: &'a str,
+        row: Option<usize>,
+        column: Option<&'a str>,
+        cx: &'a App,
+    ) -> impl Iterator<Item = &'a Diagnostic> {
+        Self::at(dataset, row, column, cx).filter(|d| d.source == Source::Note)
+    }
+
+    /// How many notes are filed here — the count a gallery tile shows.
+    pub fn note_count(dataset: &str, row: Option<usize>, column: Option<&str>, cx: &App) -> usize {
+        Self::notes_at(dataset, row, column, cx).count()
+    }
+
+    /// File another note here without disturbing the ones already at this location. `set_note`'s
+    /// counterpart: that one corrects, this one adds.
+    pub fn add_note(location: Location, message: SharedString, cx: &mut App) {
+        if message.trim().is_empty() {
+            return;
+        }
+        let filed = Self::filed_now(cx);
+        let this = cx.default_global::<Self>();
+        this.items.push(Diagnostic {
+            location,
+            severity: Severity::Note,
+            source: Source::Note,
+            message,
+            filed,
+        });
+        this.reindex();
+        this.persist();
+    }
+
+    /// Stamp for a note being filed right now: today's date from the project file's own clock, and
+    /// whoever the archivist has told the app they are. Either half may be missing.
+    fn filed_now(cx: &App) -> Option<Filed> {
+        let date = cx
+            .try_global::<settings::project::CurrentProject>()
+            .and_then(|p| settings::project::today(&p.file))
+            .map(SharedString::from);
+        // Guarded: a note can be filed before the settings globals exist (early startup, tests),
+        // and an unsigned note is a far better outcome than a panic mid-keystroke.
+        let author = match cx.has_global::<settings::AppSettings>() {
+            false => None,
+            true => match settings::effective_text(settings::NOTE_AUTHOR_KEY, cx) {
+                author if author.trim().is_empty() => None,
+                author => Some(author),
+            },
+        };
+        (date.is_some() || author.is_some()).then_some(Filed { date, author })
+    }
+
     /// Attach a note here, replacing any note already at this location; an empty `message` deletes
     /// it. Writes straight through to `__notes` — this is a deliberate keystroke, not the hot path
     /// the debounced setting writer exists for.
     pub fn set_note(location: Location, message: SharedString, cx: &mut App) {
+        // Keeps the original filing stamp: correcting a transcription is not re-observing the
+        // item, and re-dating it to today would erase when the observation was actually made.
+        let filed = Self::notes_at(
+            &location.dataset,
+            location.row,
+            location.column.as_deref(),
+            cx,
+        )
+        .next()
+        .and_then(|d| d.filed.clone())
+        .or_else(|| Self::filed_now(cx));
         let this = cx.default_global::<Self>();
         this.items
             .retain(|d| d.source != Source::Note || d.location != location);
@@ -237,6 +328,7 @@ impl Diagnostics {
                 severity: Severity::Note,
                 source: Source::Note,
                 message,
+                filed,
             });
         }
         this.reindex();
@@ -310,6 +402,14 @@ impl Diagnostics {
                 column: d.location.column.as_ref().map(|c| c.to_string()),
                 severity: d.severity.key().into(),
                 message: d.message.to_string(),
+                created_at: d
+                    .filed
+                    .as_ref()
+                    .and_then(|f| f.date.as_ref().map(SharedString::to_string)),
+                author: d
+                    .filed
+                    .as_ref()
+                    .and_then(|f| f.author.as_ref().map(SharedString::to_string)),
             })
             .collect();
         if let Err(err) = settings::project::write_notes(file, SOURCE_NOTE, &notes) {
@@ -356,6 +456,13 @@ fn load_project_notes(cx: &mut App) {
             severity: Severity::from_key(&n.severity),
             source: Source::Note,
             message: n.message.clone().into(),
+            filed: match (&n.created_at, &n.author) {
+                (None, None) => None,
+                (date, author) => Some(Filed {
+                    date: date.clone().map(SharedString::from),
+                    author: author.clone().map(SharedString::from),
+                }),
+            },
         })
         .collect();
     Diagnostics::set(&Source::Note, DATASET_MAIN, items, cx);
@@ -382,8 +489,8 @@ mod tests {
     // Never `use super::*` here: this module's parent has `use gpui::*` in scope transitively,
     // and the chained glob makes gpui's `test` macro shadow the `#[test]` its own expansion
     // emits, recursing until rustc's stack overflows.
-    use crate::{DATASET_MAIN, Diagnostic, Diagnostics, Location, Severity, Source, init};
-    use gpui::{SharedString, TestAppContext};
+    use crate::{DATASET_MAIN, Diagnostic, Diagnostics, Filed, Location, Severity, Source, init};
+    use gpui::{App, SharedString, TestAppContext};
     use settings::project::{CurrentProject, ProjectData, StoredNote};
 
     /// The row index is a second copy of the truth in `items`, so every mutation has to rebuild
@@ -435,7 +542,71 @@ mod tests {
             severity,
             source,
             message: msg.into(),
+            filed: None,
         }
+    }
+
+    /// An item accumulates observations over decades. `add_note` files another beside the ones
+    /// already there; `set_note` corrects a single one and — the part worth pinning — keeps its
+    /// original filing stamp, because fixing a typo is not re-observing the object in 2026.
+    #[gpui::test]
+    fn notes_accumulate_and_a_correction_keeps_its_original_date(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let cell = Location {
+                dataset: DATASET_MAIN.into(),
+                row: Some(1),
+                column: None,
+            };
+            let filed = |cx: &App| {
+                Diagnostics::notes_at(DATASET_MAIN, Some(1), None, cx)
+                    .map(|d| (d.message.to_string(), d.filed.clone()))
+                    .collect::<Vec<_>>()
+            };
+
+            Diagnostics::add_note(cell.clone(), "verso inscription".into(), cx);
+            Diagnostics::add_note(cell.clone(), "same backdrop as row 12".into(), cx);
+            assert_eq!(
+                Diagnostics::note_count(DATASET_MAIN, Some(1), None, cx),
+                2,
+                "a second observation joins the first rather than replacing it"
+            );
+
+            // Backdate the first, as a note loaded from an older catalogue would be.
+            let original = Some(Filed {
+                date: Some("1998-03-04".into()),
+                author: Some("MA".into()),
+            });
+            cx.default_global::<Diagnostics>().items[0].filed = original.clone();
+
+            // set_note collapses to one and keeps that stamp.
+            Diagnostics::set_note(cell, "verso inscription, in pencil".into(), cx);
+            let notes = filed(cx);
+            assert_eq!(notes.len(), 1, "a correction replaces rather than adds");
+            assert_eq!(notes[0].0, "verso inscription, in pencil");
+            assert_eq!(
+                notes[0].1, original,
+                "the filing date is not moved to today"
+            );
+        });
+    }
+
+    /// Both halves are optional, and a note with neither must not render an empty byline.
+    #[test]
+    fn a_filing_stamp_reads_as_whichever_halves_exist() {
+        let filed = |date: Option<&str>, author: Option<&str>| Filed {
+            date: date.map(SharedString::from),
+            author: author.map(SharedString::from),
+        };
+        assert_eq!(
+            filed(Some("1998-03-04"), Some("MA")).label().as_deref(),
+            Some("1998-03-04 · MA")
+        );
+        assert_eq!(
+            filed(Some("1998-03-04"), None).label().as_deref(),
+            Some("1998-03-04")
+        );
+        assert_eq!(filed(None, Some("rk")).label().as_deref(), Some("rk"));
+        assert_eq!(filed(None, None).label(), None);
     }
 
     #[gpui::test]
@@ -457,6 +628,8 @@ mod tests {
                     column: Some("Title".into()),
                     severity: "warning".into(),
                     message: "check this".into(),
+                    created_at: None,
+                    author: None,
                 },
                 StoredNote {
                     dataset: DATASET_MAIN.into(),
@@ -464,6 +637,8 @@ mod tests {
                     column: None,
                     severity: "note".into(),
                     message: "whole row".into(),
+                    created_at: None,
+                    author: None,
                 },
             ],
         )
@@ -559,6 +734,7 @@ mod tests {
                     severity: Severity::Error,
                     source: v.clone(),
                     message: "typo".into(),
+                    filed: None,
                 }],
                 cx,
             );

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -261,9 +261,31 @@ impl Diagnostics {
         Self::at(dataset, row, column, cx).filter(|d| d.source == Source::Note)
     }
 
-    /// How many notes are filed here — the count a gallery tile shows.
+    /// How many notes are filed here.
     pub fn note_count(dataset: &str, row: Option<usize>, column: Option<&str>, cx: &App) -> usize {
         Self::notes_at(dataset, row, column, cx).count()
+    }
+
+    /// Every note anywhere on one row — the ones filed on its cells as well as on the row itself,
+    /// oldest first. [`Self::at`] deliberately does *not* let a row inherit its cells' diagnostics,
+    /// because the grid marks each where it was attached; but a view with no cells to mark — the
+    /// gallery's tile, the Details panel — is describing the *item*, and to it "dated 1962 is a
+    /// guess" filed on the Date column is a note about the photograph.
+    pub fn notes_in_row<'a>(
+        dataset: &'a str,
+        row: usize,
+        cx: &'a App,
+    ) -> impl Iterator<Item = &'a Diagnostic> {
+        cx.try_global::<Self>()
+            .into_iter()
+            .flat_map(move |this| {
+                this.by_row
+                    .get(&Some(row))
+                    .map_or([].as_slice(), Vec::as_slice)
+                    .iter()
+                    .map(move |&ix| &this.items[ix])
+            })
+            .filter(move |d| d.location.dataset == dataset && d.source == Source::Note)
     }
 
     /// File another note here without disturbing the ones already at this location. `set_note`'s
@@ -529,6 +551,38 @@ mod tests {
             // Republishing nothing is how a validator clears itself.
             Diagnostics::set(&Source::Validator("v".into()), DATASET_MAIN, Vec::new(), cx);
             assert_eq!(at_00(cx), 0);
+        });
+    }
+
+    /// The gallery has no cells to mark, so a note filed on one field still has to reach it —
+    /// the bug this fixes was a tile and a Details panel showing "no notes" for a row somebody had
+    /// just annotated in the grid.
+    #[gpui::test]
+    fn a_note_on_a_cell_counts_as_a_note_on_its_row(cx: &mut TestAppContext) {
+        cx.update(|cx| {
+            let at = |column: Option<&str>| Location {
+                dataset: DATASET_MAIN.into(),
+                row: Some(3),
+                column: column.map(Into::into),
+            };
+            Diagnostics::add_note(at(Some("Date taken")), "1962 is a guess".into(), cx);
+            Diagnostics::add_note(at(None), "whole print is faded".into(), cx);
+
+            assert_eq!(
+                Diagnostics::note_count(DATASET_MAIN, Some(3), None, cx),
+                1,
+                "the grid still marks each note only where it was attached"
+            );
+            assert_eq!(
+                Diagnostics::notes_in_row(DATASET_MAIN, 3, cx).count(),
+                2,
+                "a view of the whole item sees both"
+            );
+            assert_eq!(
+                Diagnostics::notes_in_row("other", 3, cx).count(),
+                0,
+                "and only within its own dataset"
+            );
         });
     }
 

--- a/crates/diagnostics/src/panel.rs
+++ b/crates/diagnostics/src/panel.rs
@@ -419,6 +419,7 @@ mod tests {
                     severity,
                     source: Source::Note,
                     message: "m".into(),
+                    filed: None,
                 })
                 .collect(),
                 cx,
@@ -461,6 +462,7 @@ mod tests {
                             severity: Severity::Error,
                             source: Source::Validator(source.into()),
                             message: "m".into(),
+                            filed: None,
                         })
                         .collect(),
                     cx,

--- a/crates/diagnostics/src/validator.rs
+++ b/crates/diagnostics/src/validator.rs
@@ -234,6 +234,7 @@ pub fn address(
             severity: override_to.unwrap_or(severity),
             source: Source::Validator(validator.clone()),
             message,
+            filed: None,
         })
         .collect()
 }

--- a/crates/preview/src/lib.rs
+++ b/crates/preview/src/lib.rs
@@ -17,9 +17,10 @@ mod native;
 mod pdf;
 pub mod playback;
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::SystemTime;
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
@@ -156,12 +157,39 @@ impl Asset for Preview {
 
 /// How many pages this file has. One for everything that is not a document, so a caller can show
 /// page controls whenever this is greater than one without knowing which tier answered.
+///
+/// Memoized, because the gallery asks this of every visible card on every frame it draws and the
+/// answer costs a PDFium load or a walk through a TIFF's image list. Keyed by path and mtime, so a
+/// file replaced on disk is re-counted rather than answered from a stale entry.
+///
+/// ponytail: unbounded map — one `usize` per file ever previewed, which even a six-figure
+/// collection keeps in the low megabytes. Give it the byte budget `thumb` uses if that stops being
+/// true.
 pub fn page_count(path: &Path) -> usize {
-    match extension(path).as_deref() {
+    /// A file's identity for counting purposes: where it is and when it last changed.
+    type Stamp = (PathBuf, Option<SystemTime>);
+    static COUNTS: std::sync::OnceLock<std::sync::Mutex<HashMap<Stamp, usize>>> =
+        std::sync::OnceLock::new();
+
+    let key: Stamp = (
+        path.to_path_buf(),
+        std::fs::metadata(path).and_then(|m| m.modified()).ok(),
+    );
+    let counts = COUNTS.get_or_init(Default::default);
+    if let Ok(counts) = counts.lock()
+        && let Some(&pages) = counts.get(&key)
+    {
+        return pages;
+    }
+    let pages = match extension(path).as_deref() {
         Some(extension) if pdf::handles(extension) => pdf::page_count(path).unwrap_or(1),
         Some("tif" | "tiff") => tiff_pages(path),
         _ => 1,
+    };
+    if let Ok(mut counts) = counts.lock() {
+        counts.insert(key, pages);
     }
+    pages
 }
 
 /// How many images a TIFF holds. Multi-image TIFFs are ordinary in an archive — a fax, a book
@@ -595,6 +623,39 @@ mod tests {
     use gpui_component::{IconName, IconNamed as _};
 
     use crate::{can_preview, placeholder_icon, thumb};
+
+    /// The gallery asks this of every visible card on every frame, so the answer has to be cached —
+    /// but cached on the file as it is *now*, or a re-scanned document keeps reporting its old
+    /// length forever. Writing more pages into the same path must change the answer.
+    #[test]
+    fn a_page_count_is_reused_until_the_file_itself_changes() {
+        use crate::page_count;
+
+        let path = std::env::temp_dir().join("qrate-page-count-memo.tif");
+        let write = |pages: usize| {
+            let file = std::fs::File::create(&path).unwrap();
+            let mut encoder =
+                tiff::encoder::TiffEncoder::new(std::io::BufWriter::new(file)).unwrap();
+            for shade in 0..pages {
+                encoder
+                    .write_image::<tiff::encoder::colortype::Gray8>(4, 4, &[shade as u8; 16])
+                    .unwrap();
+            }
+            // mtime has one-second resolution on some filesystems, so a rewrite inside the same
+            // second would look unchanged and answer from the memo — which is the bug this is
+            // here to catch, not a flake to tolerate.
+            std::thread::sleep(std::time::Duration::from_millis(1100));
+        };
+
+        write(1);
+        assert_eq!(page_count(&path), 1);
+        assert_eq!(page_count(&path), 1, "second ask comes from the memo");
+
+        // Re-scanned at three pages: the stale entry must not survive the rewrite.
+        write(3);
+        assert_eq!(page_count(&path), 3, "a changed file is counted again");
+        std::fs::remove_file(&path).ok();
+    }
 
     /// Which loader a file is routed to, and it has to be gpui's own for an image the viewer is
     /// showing — that is what makes the fullscreen view the *original* file rather than our

--- a/crates/project-wizard/src/steps/review.rs
+++ b/crates/project-wizard/src/steps/review.rs
@@ -150,6 +150,10 @@ impl ProjectWizard {
                             column: Some(n.column.clone()),
                             severity: "note".into(),
                             message: n.text.clone(),
+                            // A spreadsheet comment carries neither, and stamping the import date
+                            // would claim the note was written the day the project was made.
+                            created_at: None,
+                            author: None,
                         })
                         .collect();
                     if let Err(e) = project::write_notes(

--- a/crates/settings/src/lib.rs
+++ b/crates/settings/src/lib.rs
@@ -37,6 +37,11 @@ pub const SETTINGS_WINDOW_BOUNDS_KEY: &str = "settings_window_bounds";
 /// or `"off"`. Read by the table crate to decide when a committed cell edit reaches disk.
 pub const AUTOSAVE_KEY: &str = "autosave";
 
+/// Setting key (either scope) for who a filed note is attributed to — initials, a name, whatever
+/// the reading room signs its marginalia with. Empty (the default) files notes with a date and no
+/// author rather than guessing at an identity from the OS account.
+pub const NOTE_AUTHOR_KEY: &str = "note_author";
+
 /// Setting key (either scope) for the string that separates several values inside one cell, e.g.
 /// `;` in `Film; Video`. Empty means a cell is one indivisible value.
 ///

--- a/crates/settings/src/project.rs
+++ b/crates/settings/src/project.rs
@@ -380,9 +380,28 @@ const NOTES_DDL: &str = r#"
       column_name TEXT,
       severity    TEXT NOT NULL,
       source      TEXT NOT NULL,
-      message     TEXT NOT NULL
+      message     TEXT NOT NULL,
+      created_at  TEXT,
+      author      TEXT
     );
 "#;
+
+/// Bring a `__notes` table written before notes carried provenance up to the columns above.
+/// Nullable, so every existing row reads back with no date and no author and renders as the bare
+/// note it has always been — there is nothing to backfill, because that information was never
+/// captured. Idempotent: a duplicate-column error is the table already being current.
+fn add_note_provenance(tx: &rusqlite::Transaction<'_>) -> Result<()> {
+    for column in ["created_at", "author"] {
+        match tx.execute(&format!("ALTER TABLE __notes ADD COLUMN {column} TEXT"), []) {
+            Ok(_) => {}
+            // `duplicate column name` is the only error worth swallowing; anything else means the
+            // table is not what we think it is and the caller should hear about it.
+            Err(err) if err.to_string().contains("duplicate column") => {}
+            Err(err) => return Err(err).context("Add note provenance"),
+        }
+    }
+    Ok(())
+}
 
 /// One `__notes` row. Deliberately flat and stringly-typed rather than reusing
 /// `diagnostics::Diagnostic`: that crate depends on this one, so the schema stays owned by the
@@ -396,6 +415,20 @@ pub struct StoredNote {
     pub column: Option<String>,
     pub severity: String,
     pub message: String,
+    /// When the note was filed and by whom, as free text. `None` on every note written before the
+    /// columns existed, and on any note filed with no author configured — a catalogue's marginalia
+    /// is worth keeping even unsigned.
+    pub created_at: Option<String>,
+    pub author: Option<String>,
+}
+
+/// Today, from SQLite's own clock — the one dependency here that already knows what day it is.
+/// Local rather than UTC: an archivist reading "filed 2026-08-14" means their own Tuesday.
+pub fn today(path: &Path) -> Option<String> {
+    open_ro(path)
+        .ok()?
+        .query_row("SELECT date('now','localtime')", [], |r| r.get(0))
+        .ok()
 }
 
 /// Every stored note. A file written before `__notes` existed yields an empty vec, the same
@@ -411,8 +444,20 @@ pub fn read_notes(path: &Path) -> Result<Vec<StoredNote>> {
         return Ok(Vec::new());
     }
 
-    let mut stmt =
-        conn.prepare("SELECT dataset, row_ix, column_name, severity, message FROM __notes")?;
+    // A file written before notes carried provenance has neither column, and `write_notes` only
+    // adds them when it next saves. Named in the projection so the read works either way.
+    let provenance: i64 = conn.query_row(
+        "SELECT count(*) FROM pragma_table_info('__notes') WHERE name = 'created_at'",
+        [],
+        |r| r.get(0),
+    )?;
+    let columns = match provenance {
+        0 => "NULL AS created_at, NULL AS author",
+        _ => "created_at, author",
+    };
+    let mut stmt = conn.prepare(&format!(
+        "SELECT dataset, row_ix, column_name, severity, message, {columns} FROM __notes"
+    ))?;
     let iter = stmt.query_map([], |r| {
         Ok(StoredNote {
             dataset: r.get(0)?,
@@ -420,6 +465,8 @@ pub fn read_notes(path: &Path) -> Result<Vec<StoredNote>> {
             column: r.get(2)?,
             severity: r.get(3)?,
             message: r.get(4)?,
+            created_at: r.get(5)?,
+            author: r.get(6)?,
         })
     })?;
     iter.collect::<rusqlite::Result<Vec<_>>>()
@@ -434,12 +481,13 @@ pub fn write_notes(path: &Path, source: &str, notes: &[StoredNote]) -> Result<()
     let mut conn = open_rw(path)?;
     let tx = conn.transaction()?;
     tx.execute_batch(NOTES_DDL).context("Create __notes")?;
+    add_note_provenance(&tx)?;
     tx.execute("DELETE FROM __notes WHERE source = ?1", params![source])
         .context("Clear notes")?;
     {
         let mut stmt = tx.prepare(
-            "INSERT INTO __notes(dataset, row_ix, column_name, severity, source, message)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            "INSERT INTO __notes(dataset, row_ix, column_name, severity, source, message, created_at, author)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
         )?;
         for n in notes {
             stmt.execute(params![
@@ -448,7 +496,9 @@ pub fn write_notes(path: &Path, source: &str, notes: &[StoredNote]) -> Result<()
                 n.column,
                 n.severity,
                 source,
-                n.message
+                n.message,
+                n.created_at,
+                n.author
             ])
             .context("Insert note")?;
         }
@@ -649,11 +699,59 @@ mod tests {
             column: column.map(str::to_string),
             severity: "note".into(),
             message: msg.into(),
+            created_at: None,
+            author: None,
         }
     }
 
     fn blank_project(path: &Path) {
         create_project_file(path, "Notes", "CSV", None, None, &[], &[], &[]).unwrap();
+    }
+
+    /// A project written before notes carried a date and an author must still open, still read its
+    /// notes, and gain the columns on the next save — losing a catalogue's marginalia to a schema
+    /// change is the one outcome here that cannot be undone.
+    #[test]
+    fn a_project_predating_note_provenance_reads_and_upgrades() {
+        let path = tempfile("notes-legacy.qrate");
+        blank_project(&path);
+
+        // The pre-provenance table, verbatim.
+        {
+            let conn = open_rw(&path).unwrap();
+            conn.execute_batch(
+                r#"
+                DROP TABLE IF EXISTS __notes;
+                CREATE TABLE __notes (
+                  dataset     TEXT NOT NULL,
+                  row_ix      INTEGER,
+                  column_name TEXT,
+                  severity    TEXT NOT NULL,
+                  source      TEXT NOT NULL,
+                  message     TEXT NOT NULL
+                );
+                INSERT INTO __notes VALUES
+                  ('dataset_main', 2, 'Title', 'note', 'import', 'verso inscription');
+                "#,
+            )
+            .unwrap();
+        }
+
+        let old = read_notes(&path).unwrap();
+        assert_eq!(old.len(), 1, "the old note survives the schema it predates");
+        assert_eq!(old[0].message, "verso inscription");
+        assert_eq!(old[0].created_at, None, "nothing to backfill, so no date");
+
+        // Saving anything upgrades the table, and a note filed now carries its provenance.
+        let mut fresh = note(Some(2), Some("Title"), "identified by her daughter");
+        fresh.created_at = Some("2026-08-14".into());
+        fresh.author = Some("rk".into());
+        write_notes(&path, "import", &[fresh]).unwrap();
+
+        let after = read_notes(&path).unwrap();
+        assert_eq!(after.len(), 1);
+        assert_eq!(after[0].created_at.as_deref(), Some("2026-08-14"));
+        assert_eq!(after[0].author.as_deref(), Some("rk"));
     }
 
     #[test]

--- a/crates/table/src/delegate.rs
+++ b/crates/table/src/delegate.rs
@@ -805,7 +805,7 @@ impl QrateTableDelegate {
 
     /// Add or remove one row from the multi-selection — ⌘-click. The cursor is folded into the set
     /// first, so the row already selected when the modifier goes down doesn't vanish.
-    pub(crate) fn toggle_row(&mut self, row: usize) {
+    pub fn toggle_row(&mut self, row: usize) {
         if let Some(Selection::Cell { row: r, .. } | Selection::Row(r)) = self.selection {
             self.selected_rows.insert(r);
         }
@@ -825,7 +825,7 @@ impl QrateTableDelegate {
     }
 
     /// Select every visible row between the cursor and `row` — shift-click down the `#` column.
-    pub(crate) fn extend_rows_to(&mut self, row: usize) {
+    pub fn extend_rows_to(&mut self, row: usize) {
         let anchor = match self.selection {
             Some(Selection::Cell { row: r, .. } | Selection::Row(r)) => r,
             Some(Selection::Column(_)) | None => row,
@@ -841,8 +841,15 @@ impl QrateTableDelegate {
         self.selection = Some(Selection::Row(row));
     }
 
-    /// Collapse back to a single row — a plain click, and what the Details panel's Clear does.
-    pub(crate) fn select_only_row(&mut self, row: usize) {
+    /// Deselect everything.
+    pub fn clear_selection(&mut self) {
+        self.selected_rows.clear();
+        self.range = None;
+        self.selection = None;
+    }
+
+    /// Collapse back to a single row — what a plain click leaves.
+    pub fn select_only_row(&mut self, row: usize) {
         self.selected_rows.clear();
         self.range = None;
         self.selection = Some(Selection::Row(row));

--- a/crates/table/src/delegate.rs
+++ b/crates/table/src/delegate.rs
@@ -53,6 +53,10 @@ pub struct QrateTableDelegate {
     /// per cell. `None` means the selection is just the one selected cell. Dropped wherever a
     /// filter or a column move invalidates a view index.
     pub(crate) range: Option<((usize, usize), (usize, usize))>,
+    /// Rows picked out by ⌘-click or a shift-click down the `#` column, as *source* indices — so a
+    /// multi-selection survives a filter change exactly as the single cursor does. Empty is the
+    /// common case: one selected row lives in `selection` alone and never reaches this set.
+    pub(crate) selected_rows: BTreeSet<usize>,
     pub(crate) editing: EditState,
     /// Shared single-line editor, reused across whichever cell is being edited.
     pub(crate) editor: Entity<InputState>,
@@ -93,6 +97,7 @@ impl QrateTableDelegate {
             rows: Vec::new(),
             selection: None,
             range: None,
+            selected_rows: BTreeSet::new(),
             editing: EditState::Idle,
             editor,
             note_edit: None,
@@ -349,6 +354,7 @@ impl QrateTableDelegate {
             .collect();
         self.selection = None;
         self.range = None;
+        self.selected_rows.clear();
         self.editing = EditState::Idle;
         // Recorded edits index into the outgoing dataset.
         self.history = History::default();
@@ -446,6 +452,13 @@ impl QrateTableDelegate {
         let Some(((ar, ac), (hr, hc))) = self.range else {
             if self.columns.is_empty() {
                 return None;
+            }
+            // A ⌘-clicked set of rows is every column of each, the same way one selected row is —
+            // so Copy, Cut, Paste and Clear widen to a multi-selection without any of them
+            // learning that multi-selection exists.
+            if !self.selected_rows.is_empty() {
+                let rows = self.selected_source_rows();
+                return (!rows.is_empty()).then(|| (rows, 0..=self.columns.len() - 1));
             }
             return match self.selection? {
                 Selection::Cell { row, col } => Some((vec![row], col..=col)),
@@ -665,6 +678,9 @@ impl QrateTableDelegate {
     /// that no longer exists.
     fn clamp_selection(&mut self) {
         let (rows, cols) = (self.rows.len(), self.columns.len());
+        // Dropped rather than clamped: two selected rows both clamping to the last one would
+        // silently merge into one selection, and a delete is exactly when that would mislead.
+        self.selected_rows.retain(|&row| row < rows);
         self.selection = match self.selection {
             _ if rows == 0 || cols == 0 => None,
             Some(Selection::Cell { row, col }) => Some(Selection::Cell {
@@ -757,6 +773,79 @@ impl QrateTableDelegate {
     /// The current selection — a cell, a whole row, or a whole column.
     pub fn selection(&self) -> Option<Selection> {
         self.selection
+    }
+
+    /// Every selected item as source rows, in view order: the ⌘-clicked set unioned with whatever
+    /// row the cursor is on. This is what Details, the gallery, the selection menu and the status
+    /// bar all count — one answer to "what is selected", so none of them can disagree.
+    ///
+    /// Filtered-away rows stay in the set but drop out here, so an action reaches what the
+    /// archivist can actually see and clearing the filter brings the rest back.
+    pub fn selected_source_rows(&self) -> Vec<usize> {
+        let cursor = match self.selection {
+            Some(Selection::Cell { row, .. } | Selection::Row(row)) => Some(row),
+            Some(Selection::Column(_)) | None => None,
+        };
+        self.visible_rows
+            .iter()
+            .copied()
+            .filter(|row| self.selected_rows.contains(row) || cursor == Some(*row))
+            .collect()
+    }
+
+    /// Whether this source row is part of a multi-selection — the cheap per-row test the grid and
+    /// the gallery run while rendering, without building the vector above.
+    pub fn is_row_selected(&self, row: usize) -> bool {
+        self.selected_rows.contains(&row)
+            || matches!(
+                self.selection,
+                Some(Selection::Cell { row: r, .. } | Selection::Row(r)) if r == row
+            )
+    }
+
+    /// Add or remove one row from the multi-selection — ⌘-click. The cursor is folded into the set
+    /// first, so the row already selected when the modifier goes down doesn't vanish.
+    pub(crate) fn toggle_row(&mut self, row: usize) {
+        if let Some(Selection::Cell { row: r, .. } | Selection::Row(r)) = self.selection {
+            self.selected_rows.insert(r);
+        }
+        self.range = None;
+        if self.selected_rows.remove(&row) {
+            // Leaving the cursor on the row just removed would count it as selected again — the
+            // cursor is part of the selection, so it has to retreat to whatever is still picked.
+            self.selection = self
+                .selected_rows
+                .iter()
+                .next_back()
+                .map(|&r| Selection::Row(r));
+            return;
+        }
+        self.selected_rows.insert(row);
+        self.selection = Some(Selection::Row(row));
+    }
+
+    /// Select every visible row between the cursor and `row` — shift-click down the `#` column.
+    pub(crate) fn extend_rows_to(&mut self, row: usize) {
+        let anchor = match self.selection {
+            Some(Selection::Cell { row: r, .. } | Selection::Row(r)) => r,
+            Some(Selection::Column(_)) | None => row,
+        };
+        let (Some(from), Some(to)) = (self.view_row(anchor), self.view_row(row)) else {
+            return;
+        };
+        let run: Vec<_> = normalize(from, to)
+            .filter_map(|view| self.source(view))
+            .collect();
+        self.selected_rows.extend(run);
+        self.range = None;
+        self.selection = Some(Selection::Row(row));
+    }
+
+    /// Collapse back to a single row — a plain click, and what the Details panel's Clear does.
+    pub(crate) fn select_only_row(&mut self, row: usize) {
+        self.selected_rows.clear();
+        self.range = None;
+        self.selection = Some(Selection::Row(row));
     }
 
     /// The `(source_row, data_col)` whose row-number and column header should be highlighted
@@ -1070,10 +1159,13 @@ impl TableDelegate for QrateTableDelegate {
         if col_ix == row_index::COL_IX {
             // The source row number — the row's stable identity, not its view position. Highlight
             // it while its row holds the active (edited/selected) cell.
-            let highlighted = self.active_cell().is_some_and(|(r, _)| r == source);
+            let highlighted = self.active_cell().is_some_and(|(r, _)| r == source)
+                || self.selected_rows.contains(&source);
             row_index::render_td(self, source, highlighted, cx)
         } else {
-            let ranged = self.in_range(row_ix, col_ix - 1);
+            // A ⌘-clicked row paints across every column, which is what makes a discontiguous
+            // selection read as a set of *items* rather than a column of tinted cells.
+            let ranged = self.in_range(row_ix, col_ix - 1) || self.selected_rows.contains(&source);
             cell::render_cell(self, source, col_ix - 1, ranged, window, cx)
         }
     }
@@ -1449,6 +1541,82 @@ mod app_tests {
                 delegate.selection = Some(super::Selection::Column(1));
                 let (rows, _) = delegate.range_cells().expect("a column is selected");
                 assert_eq!(rows, vec![0, 3]);
+            });
+        });
+    }
+
+    /// The point of putting the row set behind `range_cells`: Copy/Cut/Paste/Clear widen to a
+    /// ⌘-clicked selection without any of them being told it exists. Rows come back in view order,
+    /// not click order, so a copy pastes in the order it was read on screen.
+    #[gpui::test]
+    fn a_multi_selection_covers_every_column_of_each_row(cx: &mut TestAppContext) {
+        let state = table(cx);
+        cx.update(|cx| {
+            state.update(cx, |state, _| {
+                let delegate = state.delegate_mut();
+
+                delegate.select_only_row(3);
+                delegate.toggle_row(1);
+                let (rows, cols) = delegate.range_cells().expect("rows are selected");
+                assert_eq!(
+                    (rows, cols),
+                    (vec![1, 3], 0..=1),
+                    "view order, not click order"
+                );
+
+                // ⌘-clicking a selected row takes it back out, and the last one standing behaves
+                // exactly as a plain single selection does.
+                delegate.toggle_row(3);
+                let (rows, _) = delegate.range_cells().expect("one row is left");
+                assert_eq!(rows, vec![1]);
+            });
+        });
+    }
+
+    /// Source indices, so a filter narrows what an action reaches without forgetting the rest —
+    /// clearing the filter brings the hidden rows back to the selection they never left.
+    #[gpui::test]
+    fn a_filter_hides_selected_rows_without_dropping_them(cx: &mut TestAppContext) {
+        let state = table(cx);
+        cx.update(|cx| {
+            state.update(cx, |state, _| {
+                let delegate = state.delegate_mut();
+                delegate.select_only_row(0);
+                delegate.toggle_row(1);
+                delegate.toggle_row(2);
+                assert_eq!(delegate.selected_source_rows(), vec![0, 1, 2]);
+
+                // Rows 1 and 2 are Video; keeping Film leaves only source rows 0 and 3 visible.
+                delegate.set_column_kept(0, &["Film".into()]);
+                assert_eq!(
+                    delegate.selected_source_rows(),
+                    vec![0],
+                    "a hidden row is not something an action should reach"
+                );
+
+                delegate.set_column_kept(0, &["Film".into(), "Video".into()]);
+                assert_eq!(delegate.selected_source_rows(), vec![0, 1, 2], "all back");
+            });
+        });
+    }
+
+    /// Shift down the `#` column takes the run between the cursor and the click, in view order —
+    /// so under a filter it takes what is on screen between them, not the source rows in between.
+    #[gpui::test]
+    fn extending_a_row_selection_follows_the_view(cx: &mut TestAppContext) {
+        let state = table(cx);
+        cx.update(|cx| {
+            state.update(cx, |state, _| {
+                let delegate = state.delegate_mut();
+                delegate.set_column_kept(0, &["Film".into()]);
+                // View is source rows 0 and 3; the two Video rows between them are hidden.
+                delegate.select_only_row(0);
+                delegate.extend_rows_to(3);
+                assert_eq!(
+                    delegate.selected_source_rows(),
+                    vec![0, 3],
+                    "the hidden rows between the ends are not swept up"
+                );
             });
         });
     }

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -24,7 +24,7 @@ pub use delegate::{QrateTableDelegate, Selection, TableChanged};
 /// growing a second, quietly diverging copy.
 pub use note::{Target as MenuTarget, menu as context_menu};
 pub use panel::{
-    Clear, Copy, Cut, DeleteColumn, DeleteRow, DuplicateRow, EditCell, GRID_CONTEXT,
+    Clear, Copy, Cut, DeleteColumn, DeleteRow, Deselect, DuplicateRow, EditCell, GRID_CONTEXT,
     InsertColumnLeft, InsertColumnRight, InsertNote, InsertRowAbove, InsertRowBelow, Paste, Redo,
     RenameColumn, Replace, Search, TablePanel, Undo, UnfreezeColumns, editor_box,
 };

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -20,6 +20,9 @@ pub mod photos;
 mod row_index;
 
 pub use delegate::{QrateTableDelegate, Selection, TableChanged};
+/// The grid's right-click menu, so a gallery card can raise the same one a row does rather than
+/// growing a second, quietly diverging copy.
+pub use note::{Target as MenuTarget, menu as context_menu};
 pub use panel::{
     Clear, Copy, Cut, DeleteColumn, DeleteRow, DuplicateRow, EditCell, GRID_CONTEXT,
     InsertColumnLeft, InsertColumnRight, InsertNote, InsertRowAbove, InsertRowBelow, Paste, Redo,

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -29,7 +29,9 @@ pub use panel::{
 /// Settings key (in either scope) for the alternating-row-stripe toggle.
 pub const TABLE_STRIPES_KEY: &str = "table_stripes";
 
-use gpui::{App, Bounds, Entity, Global, Pixels, Point, SharedString, WeakEntity, px, size};
+use gpui::{
+    App, Bounds, ClipboardItem, Entity, Global, Pixels, Point, SharedString, WeakEntity, px, size,
+};
 use gpui_component::table::TableState;
 use plugin_api::CommandContext;
 
@@ -95,6 +97,47 @@ fn autosave(cx: &mut App) {
 /// committed edit does except going through the inline editor. What a fix menu applies through.
 pub fn write_cell(row: usize, col: usize, text: SharedString, cx: &mut App) {
     write_cells(vec![(row, col, text)], cx);
+}
+
+/// The selection as tab-separated text on the clipboard — what Ctrl+C copies, reachable from
+/// outside the grid so Details' "Copy N rows" puts the same thing there as the keystroke does.
+pub fn copy_selection(cx: &mut App) {
+    let Some(state) = cx
+        .try_global::<TableStateHandle>()
+        .and_then(|h| h.0.upgrade())
+    else {
+        return;
+    };
+    let delegate = state.read(cx).delegate();
+    let Some((rows, cols)) = delegate.range_cells() else {
+        return;
+    };
+    let lines: Vec<String> = rows
+        .iter()
+        .map(|&row| {
+            cols.clone()
+                .map(|col| delegate.cell(row, col).map_or("", |v| v.as_ref()))
+                .collect::<Vec<_>>()
+                .join("\t")
+        })
+        .collect();
+    cx.write_to_clipboard(ClipboardItem::new_string(lines.join("\n")));
+}
+
+/// Drop a multi-selection back to nothing — Details' "Clear". The cursor goes with it, so the
+/// panel falls to its empty state rather than silently keeping one row of the bundle.
+pub fn clear_selection(cx: &mut App) {
+    let Some(state) = cx
+        .try_global::<TableStateHandle>()
+        .and_then(|h| h.0.upgrade())
+    else {
+        return;
+    };
+    state.update(cx, |state, cx| {
+        state.delegate_mut().clear_selection();
+        cx.emit(delegate::TableChanged);
+        cx.notify();
+    });
 }
 
 /// [`write_cell`]'s bulk form: one undo step for the whole batch, one validation pass at the end,

--- a/crates/table/src/note.rs
+++ b/crates/table/src/note.rs
@@ -4,6 +4,9 @@
 //! Right-click uses `ContextMenuExt` on our own cell div, not `TableDelegate::context_menu` —
 //! that hook only fires while `right_clicked_row` is `Some`, which `on_cell_right_click` clears.
 
+// Not `Path` — `gpui::Path` is the shape the squiggle is drawn with, and it is imported below.
+use std::path::PathBuf;
+
 use gpui::prelude::FluentBuilder as _;
 use gpui::{
     AnyElement, App, ClipboardItem, Context, Entity, InteractiveElement as _, IntoElement,
@@ -41,7 +44,7 @@ const EDITOR_H: f32 = 132.;
 /// What was right-clicked. Copy/edit/filter only make sense over a cell; a row or a column can
 /// only carry a note.
 #[derive(Clone, Copy)]
-pub(crate) enum Target {
+pub enum Target {
     /// Source row and data column — not view/table indices.
     Cell {
         row: usize,
@@ -147,6 +150,63 @@ fn rows_label(verb: &str, rows: &[usize]) -> SharedString {
     }
 }
 
+/// How the reveal entry counts itself: files, not items, because a selection can hold rows that
+/// never matched one. Split out from the menu so the arithmetic is testable without a window.
+fn reveal_label(items: usize, files: usize) -> SharedString {
+    match items == files {
+        true => format!("Reveal {files} files in folder").into(),
+        false => format!("Reveal {files} of {items} files in folder").into(),
+    }
+}
+
+/// What a menu raised on a multi-selection offers before anything about the clicked cell: every
+/// label counts the items, so a command can't act on more than it said it would.
+///
+/// Only appears above one item — over a single row these would duplicate what the rest of the menu
+/// and the Details panel already offer.
+///
+/// Two entries from the design are deliberately absent. "Set field for N items…" is what the
+/// Details panel now *is* — click a field, type, it writes down the selection — and a second
+/// route through a modal would be the worse one. "Re-check file matches" is re-resolving links,
+/// which is its own command over the whole sheet, not a property of what happens to be selected.
+fn selection_items(menu: PopupMenu, rows: &[usize], files: Vec<PathBuf>) -> PopupMenu {
+    let n = rows.len();
+    if n < 2 {
+        return menu;
+    }
+    let (open, reveal) = (files.clone(), files);
+    menu.label(format!("{n} items selected"))
+        .item(
+            PopupMenuItem::new(format!("Open {} items", open.len()))
+                .disabled(open.is_empty())
+                .on_click(move |_, _, _| {
+                    for path in &open {
+                        if let Err(err) = settings::os_open::open_in_default_app(path) {
+                            log::error!("could not open {}: {err}", path.display());
+                        }
+                    }
+                }),
+        )
+        .item(
+            // Counts the files, not the items: a selection can hold rows that never matched one,
+            // and offering to reveal five files when only three exist is a lie the label can avoid.
+            PopupMenuItem::new(reveal_label(n, reveal.len()))
+                .disabled(reveal.is_empty())
+                .on_click(move |_, _, _| {
+                    for path in &reveal {
+                        if let Err(err) = settings::os_open::reveal_in_folder(path) {
+                            log::error!("could not reveal {}: {err}", path.display());
+                        }
+                    }
+                }),
+        )
+        .item(
+            PopupMenuItem::new(format!("Copy {n} rows"))
+                .on_click(move |_, _, cx| crate::copy_selection(cx)),
+        )
+        .separator()
+}
+
 /// The row and column commands every target that has a row or a column offers. Built here rather
 /// than three times over, because the cell menu is the row menu and the column menu at once.
 fn structural_items(menu: PopupMenu, rows: Option<&[usize]>, col: Option<usize>) -> PopupMenu {
@@ -222,7 +282,7 @@ fn paste_onto(row: usize, col: usize, cx: &mut App) {
 
 /// Build the right-click menu for `target`. Live state is read off the table global here rather
 /// than captured at render time, the same way `filter::filter_dropdown` does it.
-pub(crate) fn menu(
+pub fn menu(
     target: Target,
     menu: PopupMenu,
     window: &mut Window,
@@ -257,6 +317,24 @@ pub(crate) fn menu(
         location.column.as_deref(),
         cx,
     );
+
+    // Above everything else, and above both the cell and row menus, because it says what the
+    // commands below are about to act on.
+    let menu = match row {
+        Some(row) => {
+            let (rows, files) = {
+                let delegate = table.read(cx).delegate();
+                let rows = target_rows(delegate, row);
+                let files = rows
+                    .iter()
+                    .filter_map(|&row| delegate.row_image(row).map(std::path::Path::to_path_buf))
+                    .collect();
+                (rows, files)
+            };
+            selection_items(menu, &rows, files)
+        }
+        None => menu,
+    };
 
     let spell_text = cell_text.clone();
     let menu = match target {
@@ -619,6 +697,18 @@ mod tests {
     use crate::{TablePanel, TableStateHandle};
     use diagnostics::{DATASET_MAIN, Diagnostic, Diagnostics, Location, Severity, Source};
     use gpui::TestAppContext;
+
+    /// A selection can hold rows that never matched a file, so the reveal entry counts the files
+    /// it will actually open — a label promising five when three exist is the kind of small lie
+    /// that costs trust in every other count in the menu.
+    #[test]
+    fn the_reveal_entry_counts_files_not_items() {
+        use crate::note::reveal_label;
+
+        assert_eq!(reveal_label(3, 3).as_ref(), "Reveal 3 files in folder");
+        assert_eq!(reveal_label(5, 3).as_ref(), "Reveal 3 of 5 files in folder");
+        assert_eq!(reveal_label(2, 0).as_ref(), "Reveal 0 of 2 files in folder");
+    }
 
     fn at(row: Option<usize>, column: Option<&str>) -> Location {
         Location {

--- a/crates/table/src/note.rs
+++ b/crates/table/src/note.rs
@@ -746,6 +746,7 @@ mod tests {
                 severity: Severity::Note,
                 source: Source::Note,
                 message: "look at this".into(),
+                filed: None,
             };
             // A cell note, a whole-row note, and a whole-column note — one per marker site.
             Diagnostics::set(
@@ -769,6 +770,7 @@ mod tests {
                     severity: Severity::Error,
                     source: v.clone(),
                     message: "bad".into(),
+                    filed: None,
                 }],
                 cx,
             );

--- a/crates/table/src/panel.rs
+++ b/crates/table/src/panel.rs
@@ -243,9 +243,27 @@ impl TablePanel {
                         // Native selection ignores `selectable(false)`, so the `#` column reports a
                         // cell hit. Turn it into a whole-row selection — the row header's job, and
                         // the mirror of clicking a column header.
-                        let row = *row;
-                        state.update(cx, |s, cx| s.set_selected_row(row, cx));
-                        return;
+                        let view = *row;
+                        let modifiers = window.modifiers();
+                        // Shift builds a run of items here, not the cell rectangle it draws inside
+                        // the grid: the `#` column is the row handle, so a range down it is a range
+                        // of whole rows.
+                        if !modifiers.secondary() && !modifiers.shift {
+                            state.update(cx, |s, cx| {
+                                s.delegate_mut().selected_rows.clear();
+                                s.set_selected_row(view, cx);
+                            });
+                            return;
+                        }
+                        state.update(cx, |s, _| {
+                            let Some(source) = s.delegate().source(view) else {
+                                return;
+                            };
+                            match modifiers.shift {
+                                true => s.delegate_mut().extend_rows_to(source),
+                                false => s.delegate_mut().toggle_row(source),
+                            }
+                        });
                     }
                     TableEvent::SelectCell(view, col) => {
                         // `view` is a VIEW index; store the SOURCE row so the selection survives a
@@ -255,9 +273,26 @@ impl TablePanel {
                         // ponytail: shift-click only. Extending with shift+arrow means forking the
                         // library's cell-navigation key handling; do that if anyone asks.
                         let (view, col) = (*view, *col - 1);
-                        let extend = window.modifiers().shift;
+                        let modifiers = window.modifiers();
+                        // ⌘-click picks whole items wherever it lands, so a multi-selection can be
+                        // built without aiming at the narrow `#` column.
+                        if modifiers.secondary() {
+                            state.update(cx, |s, cx| {
+                                if let Some(source) = s.delegate().source(view) {
+                                    s.delegate_mut().toggle_row(source);
+                                }
+                                cx.emit(TableChanged);
+                            });
+                            return;
+                        }
+                        let extend = modifiers.shift;
                         state.update(cx, |s, _| {
                             let delegate = s.delegate_mut();
+                            // A plain click is a fresh start; a shift-click is still growing the
+                            // cell rectangle and must not drop the items it was drawn from.
+                            if !extend {
+                                delegate.selected_rows.clear();
+                            }
                             delegate.range = match (extend, delegate.range) {
                                 // Grow the existing rectangle from its original anchor.
                                 (true, Some((anchor, _))) => Some((anchor, (view, col))),

--- a/crates/table/src/panel.rs
+++ b/crates/table/src/panel.rs
@@ -656,20 +656,7 @@ impl TablePanel {
     /// Put the selected range on the clipboard as TSV — what Sheets and Excel both read and write,
     /// so a range copied here pastes into either. `cut` blanks the range afterwards, as one undo.
     fn copy_range(&mut self, cut: bool, cx: &mut Context<Self>) {
-        let Some((rows, cols)) = self.state.read(cx).delegate().range_cells() else {
-            return;
-        };
-        let delegate = self.state.read(cx).delegate();
-        let mut lines = Vec::with_capacity(rows.len());
-        for &row in &rows {
-            let line: Vec<&str> = cols
-                .clone()
-                .map(|col| delegate.cell(row, col).map_or("", |v| v.as_ref()))
-                .collect();
-            lines.push(line.join("\t"));
-        }
-        cx.write_to_clipboard(ClipboardItem::new_string(lines.join("\n")));
-
+        crate::copy_selection(cx);
         if cut {
             self.clear_range(cx);
         }

--- a/crates/table/src/panel.rs
+++ b/crates/table/src/panel.rs
@@ -54,6 +54,7 @@ actions!(
         Copy,
         Paste,
         Clear,
+        Deselect,
         EditCell,
         InsertNote,
         UnfreezeColumns,

--- a/crates/workspace/src/lib.rs
+++ b/crates/workspace/src/lib.rs
@@ -12,7 +12,7 @@ pub use viewer::{Scope as ViewerScope, open_viewer};
 pub use dock_button::DockToggleButton;
 pub use panel_registry::{BarSide, PANELS, PanelMeta, PanelRegistry, bar_side};
 pub use panels::DETAILS_META;
-pub use views::{ShowView, VIEW_MODE_KEY, ViewMode, show_view};
+pub use views::{ShowView, VIEW_MODE_KEY, VIEWS_CONTEXT, ViewMode, show_view};
 
 use std::sync::Arc;
 

--- a/crates/workspace/src/panels/details.rs
+++ b/crates/workspace/src/panels/details.rs
@@ -954,16 +954,6 @@ impl Render for DetailsPanel {
                                 }),
                         )
                     })
-                    // The gallery has no preview pane, so the notes go where it was — and that is
-                    // the view where a tile can say "2 notes" without showing a word of them.
-                    .when_some(notes, |split, notes| {
-                        split.child(
-                            resizable_panel()
-                                .size(px(180.))
-                                .size_range(px(28.)..px(320.))
-                                .child(notes),
-                        )
-                    })
                     .child(
                         // `pr_2` on the panel insets the scrollbar from the resize edge so dragging it doesn't catch.
                         resizable_panel().pr_2().child(
@@ -1048,7 +1038,18 @@ impl Render for DetailsPanel {
                                 })
                                 .children(self.field_editor(window, cx)),
                         ),
-                    ),
+                    )
+                    // Last, along the bottom: the fields are what the panel is for, and a note is
+                    // commentary on them. Reading order puts the thing before what is said about
+                    // it, and it keeps the fields anchored under the photo as the notes grow.
+                    .when_some(notes, |split, notes| {
+                        split.child(
+                            resizable_panel()
+                                .size(px(180.))
+                                .size_range(px(28.)..px(320.))
+                                .child(notes),
+                        )
+                    }),
             )
             .into_any_element()
     }

--- a/crates/workspace/src/panels/details.rs
+++ b/crates/workspace/src/panels/details.rs
@@ -6,13 +6,15 @@ use std::rc::Rc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    ActiveTheme, IconName, Sizable,
+    ActiveTheme, Icon, IconName, Sizable, StyledExt as _,
     button::{Button, ButtonVariants},
     dock::{DockPlacement, Panel, PanelControl, PanelEvent},
+    h_flex,
     input::{Escape, InputEvent, InputState},
     resizable::{resizable_panel, v_resizable},
     scroll::ScrollableElement,
     table::TableState,
+    v_flex,
 };
 use preview::{can_preview, thumb};
 use table::{QrateTableDelegate, TableChanged, TableStateHandle};
@@ -67,6 +69,9 @@ pub struct DetailsPanel {
     /// it — the step arrows only exist while it is, so they never cover the photo at rest.
     stack: usize,
     stack_hover: bool,
+    /// Whether the Notes sub-panel is expanded. Open by default: in the gallery it is the only
+    /// place the text of a note is readable at all.
+    notes_open: bool,
     /// Commits the open field on Enter or when the editor loses focus.
     _editor_sub: Subscription,
     /// Window-space rect of the field row being edited, and of the scrolling field list the
@@ -115,6 +120,7 @@ impl DetailsPanel {
             editing: None,
             stack: 0,
             stack_hover: false,
+            notes_open: true,
             _editor_sub,
             anchor: Rc::default(),
             viewport: Rc::new(Cell::new(Bounds::default())),
@@ -208,6 +214,144 @@ impl DetailsPanel {
             editor.focus(window, cx);
         });
         cx.notify();
+    }
+
+    /// The Notes sub-panel: a collapsible list of what has been written about the selection, newest
+    /// group last, headed by the item it belongs to once more than one item is picked.
+    ///
+    /// Returns `AnyElement` because it is one child of a deeply chained builder — see the note on
+    /// `render_image_frame`.
+    fn notes_panel(&self, picked: &[usize], cx: &mut Context<Self>) -> AnyElement {
+        let Some(state) = self.state.as_ref().and_then(|w| w.upgrade()) else {
+            return div().into_any_element();
+        };
+        let delegate = state.read(cx);
+        let delegate = delegate.delegate();
+        /// One note as the panel draws it: what it says, and who filed it when.
+        type Note = (SharedString, Option<SharedString>);
+        /// The notes on one selected item, under that item's title.
+        type Group = (SharedString, Vec<Note>);
+
+        let groups: Vec<Group> = picked
+            .iter()
+            .filter_map(|&row| {
+                let notes: Vec<_> = diagnostics::Diagnostics::notes_at(
+                    diagnostics::DATASET_MAIN,
+                    Some(row),
+                    None,
+                    cx,
+                )
+                .map(|note| {
+                    (
+                        note.message.clone(),
+                        note.filed.as_ref().and_then(diagnostics::Filed::label),
+                    )
+                })
+                .collect();
+                if notes.is_empty() {
+                    return None;
+                }
+                let title = delegate
+                    .row_fields(row)
+                    .into_iter()
+                    .map(|(_, value)| value)
+                    .find(|value| !value.is_empty())
+                    .unwrap_or_default();
+                Some((title, notes))
+            })
+            .collect();
+        let total: usize = groups.iter().map(|(_, notes)| notes.len()).sum();
+        let several = picked.len() > 1;
+        let open = self.notes_open;
+
+        v_flex()
+            .size_full()
+            .min_h_0()
+            .border_t_1()
+            .border_color(cx.theme().border)
+            .child(
+                h_flex()
+                    .id("details-notes-header")
+                    .flex_none()
+                    .h(px(28.))
+                    .items_center()
+                    .gap_1p5()
+                    .px_3()
+                    .cursor_pointer()
+                    .hover(|header| header.bg(cx.theme().accent))
+                    .on_click(cx.listener(|this, _, _, cx| {
+                        this.notes_open = !this.notes_open;
+                        cx.notify();
+                    }))
+                    .child(
+                        Icon::new(match open {
+                            true => IconName::ChevronDown,
+                            false => IconName::ChevronRight,
+                        })
+                        .xsmall()
+                        .text_color(cx.theme().muted_foreground),
+                    )
+                    .child(div().text_xs().font_semibold().child("Notes"))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(match total {
+                                0 => "none".to_string(),
+                                n => n.to_string(),
+                            }),
+                    ),
+            )
+            .when(open, |panel| {
+                panel.child(
+                    div()
+                        .flex_1()
+                        .min_h_0()
+                        .overflow_y_scrollbar()
+                        .px_3()
+                        .pb_2()
+                        .child(
+                            v_flex()
+                                .gap_2()
+                                .children(groups.into_iter().map(|(title, notes)| {
+                                    v_flex()
+                                        .gap_1()
+                                        // Only worth saying whose note this is when the selection
+                                        // holds more than one item to confuse it with.
+                                        .when(several, |group| {
+                                            group.child(
+                                                div().text_xs().truncate().child(title.clone()),
+                                            )
+                                        })
+                                        .children(notes.into_iter().map(|(text, meta)| {
+                                            v_flex()
+                                                .gap_0p5()
+                                                .p_1p5()
+                                                .rounded(cx.theme().radius)
+                                                .border_1()
+                                                .border_color(cx.theme().border)
+                                                .bg(cx.theme().muted.opacity(0.4))
+                                                .child(div().text_xs().child(text))
+                                                .children(meta.map(|meta| {
+                                                    div()
+                                                        .text_xs()
+                                                        .text_color(cx.theme().muted_foreground)
+                                                        .child(meta)
+                                                }))
+                                        }))
+                                }))
+                                .when(total == 0, |list| {
+                                    list.child(
+                                        div()
+                                            .text_xs()
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child("No notes on this selection."),
+                                    )
+                                }),
+                        ),
+                )
+            })
+            .into_any_element()
     }
 
     /// Move the preview stack one item along, wrapping at both ends so a bundle can be walked in
@@ -572,6 +716,10 @@ impl Render for DetailsPanel {
                 .into_any_element();
         };
 
+        // Built before the field rows below, which borrow `cx` for as long as they stay a lazy
+        // iterator — this needs `&mut cx` and cannot wait for them.
+        let notes = (gallery && count > 0).then(|| self.notes_panel(&picked, cx));
+
         // Hand-built attribute list, not `DescriptionList`/`DataTable`: the fields are fixed pairs,
         // and it reads as a list rather than a second grid — alternating rows carry the structure,
         // no borders.
@@ -804,6 +952,16 @@ impl Render for DetailsPanel {
                                             ),
                                     ),
                                 }),
+                        )
+                    })
+                    // The gallery has no preview pane, so the notes go where it was — and that is
+                    // the view where a tile can say "2 notes" without showing a word of them.
+                    .when_some(notes, |split, notes| {
+                        split.child(
+                            resizable_panel()
+                                .size(px(180.))
+                                .size_range(px(28.)..px(320.))
+                                .child(notes),
                         )
                     })
                     .child(

--- a/crates/workspace/src/panels/details.rs
+++ b/crates/workspace/src/panels/details.rs
@@ -6,7 +6,7 @@ use std::rc::Rc;
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{
-    ActiveTheme, Icon, IconName, Sizable, StyledExt as _,
+    ActiveTheme, IconName, Sizable, StyledExt as _,
     button::{Button, ButtonVariants},
     dock::{DockPlacement, Panel, PanelControl, PanelEvent},
     h_flex,
@@ -25,6 +25,9 @@ use crate::viewer::transport::{self, Transport};
 
 /// Project-scoped height of the details panel's image pane, in pixels.
 const IMAGE_PANE_HEIGHT_KEY: &str = "details_image_height";
+
+/// Height of the Notes sub-panel's header bar, which is the whole of it while collapsed.
+const NOTES_HEADER_H: f32 = 28.;
 
 /// How much of the window the open field editor may span when the panel itself is narrower.
 const EDITOR_MAX_WINDOW_SHARE: f32 = 0.4;
@@ -69,8 +72,8 @@ pub struct DetailsPanel {
     /// it — the step arrows only exist while it is, so they never cover the photo at rest.
     stack: usize,
     stack_hover: bool,
-    /// Whether the Notes sub-panel is expanded. Open by default: in the gallery it is the only
-    /// place the text of a note is readable at all.
+    /// Whether the Notes sub-panel is expanded. Collapsed, it leaves the split and becomes a
+    /// header strip along the bottom of the panel — the chevron there is what opens it again.
     notes_open: bool,
     /// Commits the open field on Enter or when the editor loses focus.
     _editor_sub: Subscription,
@@ -235,19 +238,21 @@ impl DetailsPanel {
         let groups: Vec<Group> = picked
             .iter()
             .filter_map(|&row| {
-                let notes: Vec<_> = diagnostics::Diagnostics::notes_at(
-                    diagnostics::DATASET_MAIN,
-                    Some(row),
-                    None,
-                    cx,
-                )
-                .map(|note| {
-                    (
-                        note.message.clone(),
-                        note.filed.as_ref().and_then(diagnostics::Filed::label),
-                    )
-                })
-                .collect();
+                let notes: Vec<_> =
+                    diagnostics::Diagnostics::notes_in_row(diagnostics::DATASET_MAIN, row, cx)
+                        .map(|note| {
+                            // Which field it hangs off, when it hangs off one: without it a note
+                            // about the date and a note about the photographer read as two
+                            // remarks on the same thing.
+                            let filed = note.filed.as_ref().and_then(diagnostics::Filed::label);
+                            let meta = match (note.location.column.as_ref(), filed) {
+                                (Some(column), Some(filed)) => Some(format!("{column} · {filed}")),
+                                (Some(column), None) => Some(column.to_string()),
+                                (None, filed) => filed.map(Into::into),
+                            };
+                            (note.message.clone(), meta.map(SharedString::from))
+                        })
+                        .collect();
                 if notes.is_empty() {
                     return None;
                 }
@@ -262,8 +267,8 @@ impl DetailsPanel {
             .collect();
         let total: usize = groups.iter().map(|(_, notes)| notes.len()).sum();
         let several = picked.len() > 1;
-        let open = self.notes_open;
 
+        let open = self.notes_open;
         v_flex()
             .size_full()
             .min_h_0()
@@ -271,25 +276,31 @@ impl DetailsPanel {
             .border_color(cx.theme().border)
             .child(
                 h_flex()
-                    .id("details-notes-header")
                     .flex_none()
-                    .h(px(28.))
+                    .h(px(NOTES_HEADER_H))
                     .items_center()
                     .gap_1p5()
-                    .px_3()
-                    .cursor_pointer()
-                    .hover(|header| header.bg(cx.theme().accent))
-                    .on_click(cx.listener(|this, _, _, cx| {
-                        this.notes_open = !this.notes_open;
-                        cx.notify();
-                    }))
+                    .px_2()
+                    .py_1()
+                    // Opaque: the notes scroll under this, and a transparent strip let them read
+                    // through the heading.
+                    .bg(cx.theme().background)
                     .child(
-                        Icon::new(match open {
-                            true => IconName::ChevronDown,
-                            false => IconName::ChevronRight,
-                        })
-                        .xsmall()
-                        .text_color(cx.theme().muted_foreground),
+                        Button::new("details-notes-toggle")
+                            .icon(match open {
+                                true => IconName::ChevronDown,
+                                false => IconName::ChevronRight,
+                            })
+                            .ghost()
+                            .xsmall()
+                            .tooltip(match open {
+                                true => "Collapse notes",
+                                false => "Expand notes",
+                            })
+                            .on_click(cx.listener(|this, _, _, cx| {
+                                this.notes_open = !this.notes_open;
+                                cx.notify();
+                            })),
                     )
                     .child(div().text_xs().font_semibold().child("Notes"))
                     .child(
@@ -302,14 +313,17 @@ impl DetailsPanel {
                             }),
                     ),
             )
-            .when(open, |panel| {
-                panel.child(
+            .when(open, |section| {
+                let crop = cx.try_global::<BottomDockCrop>().map_or(px(0.), |c| c.0);
+                section.child(
                     div()
                         .flex_1()
                         .min_h_0()
                         .overflow_y_scrollbar()
                         .px_3()
-                        .pb_2()
+                        // Same crop compensation the field list makes: the closed bottom dock's
+                        // strip covers this panel's last 29px, which is where the newest note sits.
+                        .pb(px(8.) + crop)
                         .child(
                             v_flex()
                                 .gap_2()
@@ -595,6 +609,7 @@ fn step(
     id: &'static str,
     left: bool,
     on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+    cx: &App,
 ) -> AnyElement {
     div()
         .absolute()
@@ -607,18 +622,27 @@ fn step(
         .flex()
         .items_center()
         .child(
-            Button::new(id)
-                .icon(match left {
-                    true => IconName::ChevronLeft,
-                    false => IconName::ChevronRight,
-                })
-                .ghost()
-                .small()
-                .tooltip(match left {
-                    true => "Previous selected item",
-                    false => "Next selected item",
-                })
-                .on_click(on_click),
+            // Opaque chip under the chevron, like the caption and the action buttons: a ghost
+            // button alone is a thin glyph over whatever the photo happens to be, and it vanished
+            // against both a dark scan and a blown-out one.
+            div()
+                .rounded(cx.theme().radius)
+                .bg(cx.theme().background)
+                .shadow_sm()
+                .child(
+                    Button::new(id)
+                        .icon(match left {
+                            true => IconName::ChevronLeft,
+                            false => IconName::ChevronRight,
+                        })
+                        .ghost()
+                        .small()
+                        .tooltip(match left {
+                            true => "Previous selected item",
+                            false => "Next selected item",
+                        })
+                        .on_click(on_click),
+                ),
         )
         .into_any_element()
 }
@@ -719,6 +743,20 @@ impl Render for DetailsPanel {
         // Built before the field rows below, which borrow `cx` for as long as they stay a lazy
         // iterator — this needs `&mut cx` and cannot wait for them.
         let notes = (gallery && count > 0).then(|| self.notes_panel(&picked, cx));
+        // Collapsing pins the panel's size range to its header instead of taking it out of the
+        // split. Removing it re-syncs the group — every panel's size is rescaled to the container
+        // when the count changes — so the fields jumped on the way out and the notes came back at
+        // whatever height that rescale had left, not the one they were dragged to. Pinned, the
+        // stored size is never touched, and reopening restores it exactly.
+        //
+        // The floor includes the crop because the header sits at the top of the panel: a closed
+        // bottom dock covers the side docks' last 29px, and without the allowance the whole
+        // collapsed bar lands inside that band.
+        let collapsed_h = NOTES_HEADER_H + f32::from(crop);
+        let notes_range = match self.notes_open {
+            true => px(80.)..px(320.),
+            false => px(collapsed_h)..px(collapsed_h),
+        };
 
         // Hand-built attribute list, not `DescriptionList`/`DataTable`: the fields are fixed pairs,
         // and it reads as a list rather than a second grid — alternating rows carry the structure,
@@ -831,7 +869,10 @@ impl Render for DetailsPanel {
             .size_full()
             .key_context(DETAILS_META.name)
             .track_focus(&self.focus_handle)
-            // The editor propagates Escape rather than consuming it, so discard the edit here.
+            // The editor propagates Escape rather than consuming it, so discard the edit here. With
+            // no editor open the key isn't this action at all — the panel's own `escape` binding
+            // makes it `table::Deselect`, which is what replaces the Clear button the bundle used
+            // to carry.
             .on_action(cx.listener(|this, _: &Escape, window, cx| {
                 if this.editing.take().is_some() {
                     this.focus_handle.focus(window, cx);
@@ -839,217 +880,217 @@ impl Render for DetailsPanel {
                 }
             }))
             .child(
-                v_resizable("details-split")
-                    .on_resize(|state, _, cx| {
-                        if cx.has_global::<settings::project::CurrentProject>()
-                            && let Some(height) = state.read(cx).sizes().first().copied()
-                        {
-                            settings::project::CurrentProject::set_text(
-                                IMAGE_PANE_HEIGHT_KEY,
-                                format!("{}", f32::from(height)).into(),
-                                cx,
-                            );
-                        }
-                    })
-                    // Dropped entirely in the gallery: the cards are already showing this photo,
-                    // so the pane is just less room for the fields. It comes back with the grid.
-                    .when(!gallery, |split| {
-                        split.child(
-                            resizable_panel()
-                                .size(px(image_height))
-                                .size_range(px(80.)..px(600.))
-                                .p_3()
-                                // One item is a plain frame. Several are a stack of offset cards
-                                // with the front one live: the bundle keeps a slot per item —
-                                // including an item with no file, which shows its placeholder
-                                // rather than being skipped — so stepping through is a walk over
-                                // the selection, not over the subset that happens to have photos.
-                                .map(|pane| match count > 1 {
-                                    false => pane.child(render_image_frame(
-                                        image_path,
-                                        self.caption.clone(),
-                                        transport,
-                                        cx,
-                                    )),
-                                    true => pane.child(
-                                        div()
-                                            .id("details-stack")
-                                            .relative()
-                                            .size_full()
-                                            .on_hover(cx.listener(|this, over: &bool, _, cx| {
-                                                this.stack_hover = *over;
-                                                cx.notify();
-                                            }))
-                                            .child(
-                                                div()
-                                                    .absolute()
-                                                    .left(px(14.))
-                                                    .right_0()
-                                                    .top(px(10.))
-                                                    .bottom_0()
-                                                    .rounded(cx.theme().radius)
-                                                    .border_1()
-                                                    .border_color(cx.theme().border)
-                                                    .bg(cx.theme().muted),
-                                            )
-                                            .child(
-                                                div()
-                                                    .absolute()
-                                                    .left(px(7.))
-                                                    .right(px(7.))
-                                                    .top(px(5.))
-                                                    .bottom(px(5.))
-                                                    .rounded(cx.theme().radius)
-                                                    .border_1()
-                                                    .border_color(cx.theme().border)
-                                                    .bg(cx.theme().background),
-                                            )
-                                            .child(
-                                                div()
-                                                    .absolute()
-                                                    .left_0()
-                                                    .right(px(14.))
-                                                    .top_0()
-                                                    .bottom(px(10.))
-                                                    .child(render_image_frame(
-                                                        image_path,
-                                                        self.caption.clone(),
-                                                        transport,
-                                                        cx,
-                                                    ))
-                                                    .when(self.stack_hover, |front| {
-                                                        front
-                                                            .child(step(
-                                                                "details-stack-prev",
-                                                                true,
-                                                                cx.listener(|this, _, _, cx| {
-                                                                    this.step_stack(false, cx)
-                                                                }),
-                                                            ))
-                                                            .child(step(
-                                                                "details-stack-next",
-                                                                false,
-                                                                cx.listener(|this, _, _, cx| {
-                                                                    this.step_stack(true, cx)
-                                                                }),
-                                                            ))
-                                                    })
-                                                    .child(
-                                                        div()
-                                                            .absolute()
-                                                            .bottom_0()
-                                                            .right_0()
-                                                            .px_1()
-                                                            .rounded(cx.theme().radius)
-                                                            .bg(cx.theme().background.opacity(0.7))
-                                                            .text_xs()
-                                                            .text_color(cx.theme().muted_foreground)
-                                                            .child(format!(
-                                                                "{} of {count}",
-                                                                self.stack.min(count - 1) + 1
-                                                            )),
-                                                    ),
-                                            ),
-                                    ),
-                                }),
-                        )
-                    })
-                    .child(
-                        // `pr_2` on the panel insets the scrollbar from the resize edge so dragging it doesn't catch.
-                        resizable_panel().pr_2().child(
-                            // This wrapper does not scroll, and that is the whole point: it is the
-                            // rect the floating editor grows within and is clamped to, so a long
-                            // value wraps inside the visible list rather than over the preview or
-                            // the grid. `overflow_y_scrollbar` makes the div it is called on the
-                            // scrolled *content* (auto height, sliding under the viewport), so
-                            // measuring there would hand the editor a rect taller than the panel.
-                            // Same arrangement the grid uses for its cell editor.
-                            div()
-                                .size_full()
-                                .min_h_0()
-                                .relative()
-                                .child({
-                                    let viewport = self.viewport.clone();
-                                    canvas(
-                                        move |bounds, _, _| viewport.set(bounds),
-                                        |_, _, _, _| {},
-                                    )
-                                    .absolute()
-                                    .size_full()
-                                })
-                                // Says how many items the fields below speak for, and warns that
-                                // typing into one writes down the whole bundle — before the edit,
-                                // not after it.
-                                .when(count > 1, |list| {
-                                    list.child(
-                                        div()
-                                            .flex()
-                                            .items_center()
-                                            .justify_between()
-                                            .pb_1p5()
-                                            .text_xs()
-                                            .text_color(cx.theme().muted_foreground)
-                                            .child(format!("{count} items · shared fields"))
-                                            .child("edits apply to all"),
-                                    )
-                                })
-                                .child(
-                                    div()
-                                        .size_full()
-                                        // `min_h_0` overrides flex `min-height: auto` so this scrolls instead of growing past the panel.
-                                        .min_h_0()
-                                        .overflow_y_scrollbar()
-                                        .px_3()
-                                        // Clear of the resize handle above, so the first field
-                                        // doesn't sit flush against it.
-                                        .pt_2()
-                                        // Pad by the bottom-strip crop (29px closed / 0 open) so it doesn't eat the last field row.
-                                        .pb(px(12.) + crop)
-                                        .child(
+                div().size_full().min_h_0().child(
+                    v_resizable("details-split")
+                        .on_resize(|state, _, cx| {
+                            if cx.has_global::<settings::project::CurrentProject>()
+                                && let Some(height) = state.read(cx).sizes().first().copied()
+                            {
+                                settings::project::CurrentProject::set_text(
+                                    IMAGE_PANE_HEIGHT_KEY,
+                                    format!("{}", f32::from(height)).into(),
+                                    cx,
+                                );
+                            }
+                        })
+                        // Dropped entirely in the gallery: the cards are already showing this photo,
+                        // so the pane is just less room for the fields. It comes back with the grid.
+                        .when(!gallery, |split| {
+                            split.child(
+                                resizable_panel()
+                                    .size(px(image_height))
+                                    .size_range(px(80.)..px(600.))
+                                    .p_3()
+                                    // One item is a plain frame. Several are a stack of offset cards
+                                    // with the front one live: the bundle keeps a slot per item —
+                                    // including an item with no file, which shows its placeholder
+                                    // rather than being skipped — so stepping through is a walk over
+                                    // the selection, not over the subset that happens to have photos.
+                                    .map(|pane| match count > 1 {
+                                        false => pane.child(render_image_frame(
+                                            image_path,
+                                            self.caption.clone(),
+                                            transport,
+                                            cx,
+                                        )),
+                                        true => pane.child(
                                             div()
-                                                .rounded(cx.theme().radius)
-                                                .overflow_hidden()
-                                                .children(rows),
+                                                .id("details-stack")
+                                                .relative()
+                                                .size_full()
+                                                .on_hover(cx.listener(
+                                                    |this, over: &bool, _, cx| {
+                                                        this.stack_hover = *over;
+                                                        cx.notify();
+                                                    },
+                                                ))
+                                                .child(
+                                                    div()
+                                                        .absolute()
+                                                        .left(px(14.))
+                                                        .right_0()
+                                                        .top(px(10.))
+                                                        .bottom_0()
+                                                        .rounded(cx.theme().radius)
+                                                        .border_1()
+                                                        .border_color(cx.theme().border)
+                                                        .bg(cx.theme().muted),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .absolute()
+                                                        .left(px(7.))
+                                                        .right(px(7.))
+                                                        .top(px(5.))
+                                                        .bottom(px(5.))
+                                                        .rounded(cx.theme().radius)
+                                                        .border_1()
+                                                        .border_color(cx.theme().border)
+                                                        .bg(cx.theme().background),
+                                                )
+                                                .child(
+                                                    div()
+                                                        .absolute()
+                                                        .left_0()
+                                                        .right(px(14.))
+                                                        .top_0()
+                                                        .bottom(px(10.))
+                                                        .child(render_image_frame(
+                                                            image_path,
+                                                            self.caption.clone(),
+                                                            transport,
+                                                            cx,
+                                                        ))
+                                                        .when(self.stack_hover, |front| {
+                                                            front
+                                                                .child(step(
+                                                                    "details-stack-prev",
+                                                                    true,
+                                                                    cx.listener(
+                                                                        |this, _, _, cx| {
+                                                                            this.step_stack(
+                                                                                false, cx,
+                                                                            )
+                                                                        },
+                                                                    ),
+                                                                    cx,
+                                                                ))
+                                                                .child(step(
+                                                                    "details-stack-next",
+                                                                    false,
+                                                                    cx.listener(
+                                                                        |this, _, _, cx| {
+                                                                            this.step_stack(
+                                                                                true, cx,
+                                                                            )
+                                                                        },
+                                                                    ),
+                                                                    cx,
+                                                                ))
+                                                        })
+                                                        .child(
+                                                            div()
+                                                                .absolute()
+                                                                .bottom_1()
+                                                                .right_1()
+                                                                .px_1p5()
+                                                                .py_0p5()
+                                                                .rounded(cx.theme().radius)
+                                                                .bg(cx.theme().background)
+                                                                .text_xs()
+                                                                .text_color(cx.theme().foreground)
+                                                                .child(format!(
+                                                                    "{} of {count}",
+                                                                    self.stack.min(count - 1) + 1
+                                                                )),
+                                                        ),
+                                                ),
                                         ),
-                                )
-                                .when(count > 1, |list| {
-                                    list.child(
+                                    }),
+                            )
+                        })
+                        .child(
+                            // `pr_2` on the panel insets the scrollbar from the resize edge so dragging it doesn't catch.
+                            resizable_panel().pr_2().child(
+                                // This wrapper does not scroll, and that is the whole point: it is the
+                                // rect the floating editor grows within and is clamped to, so a long
+                                // value wraps inside the visible list rather than over the preview or
+                                // the grid. `overflow_y_scrollbar` makes the div it is called on the
+                                // scrolled *content* (auto height, sliding under the viewport), so
+                                // measuring there would hand the editor a rect taller than the panel.
+                                // Same arrangement the grid uses for its cell editor.
+                                // A flex column, not a plain block: the bundle heading below is a
+                                // sibling of the scrolling list, and with `size_full` on both the list
+                                // ran the heading's height past the bottom of the panel and cut its
+                                // last field row in half.
+                                v_flex()
+                                    .size_full()
+                                    .min_h_0()
+                                    .relative()
+                                    .child({
+                                        let viewport = self.viewport.clone();
+                                        canvas(
+                                            move |bounds, _, _| viewport.set(bounds),
+                                            |_, _, _, _| {},
+                                        )
+                                        .absolute()
+                                        .size_full()
+                                    })
+                                    // Says how many items the fields below speak for, and warns that
+                                    // typing into one writes down the whole bundle — before the edit,
+                                    // not after it.
+                                    .when(count > 1, |list| {
+                                        list.child(
+                                            div()
+                                                .flex_none()
+                                                .flex()
+                                                .items_center()
+                                                .justify_between()
+                                                .px_3()
+                                                .pt_2()
+                                                .pb_1p5()
+                                                .text_xs()
+                                                .text_color(cx.theme().muted_foreground)
+                                                .child(format!("{count} items · shared fields"))
+                                                .child("edits apply to all"),
+                                        )
+                                    })
+                                    .child(
                                         div()
-                                            .flex()
-                                            .gap_1p5()
+                                            .flex_1()
+                                            .w_full()
+                                            // `min_h_0` overrides flex `min-height: auto` so this scrolls instead of growing past the panel.
+                                            .min_h_0()
+                                            .overflow_y_scrollbar()
+                                            .px_3()
+                                            // Clear of the resize handle above, so the first field
+                                            // doesn't sit flush against it.
                                             .pt_2()
+                                            // Pad by the bottom-strip crop (29px closed / 0 open) so it doesn't eat the last field row.
+                                            .pb(px(12.) + crop)
                                             .child(
-                                                Button::new("details-copy-rows")
-                                                    .label(format!("Copy {count} rows"))
-                                                    .small()
-                                                    .flex_1()
-                                                    .on_click(|_, _, cx| table::copy_selection(cx)),
-                                            )
-                                            .child(
-                                                Button::new("details-clear-selection")
-                                                    .label("Clear")
-                                                    .ghost()
-                                                    .small()
-                                                    .on_click(|_, _, cx| {
-                                                        table::clear_selection(cx)
-                                                    }),
+                                                div()
+                                                    .rounded(cx.theme().radius)
+                                                    .overflow_hidden()
+                                                    .children(rows),
                                             ),
                                     )
-                                })
-                                .children(self.field_editor(window, cx)),
-                        ),
-                    )
-                    // Last, along the bottom: the fields are what the panel is for, and a note is
-                    // commentary on them. Reading order puts the thing before what is said about
-                    // it, and it keeps the fields anchored under the photo as the notes grow.
-                    .when_some(notes, |split, notes| {
-                        split.child(
-                            resizable_panel()
-                                .size(px(180.))
-                                .size_range(px(28.)..px(320.))
-                                .child(notes),
+                                    .children(self.field_editor(window, cx)),
+                            ),
                         )
-                    }),
+                        // Last, along the bottom: the fields are what the panel is for, and a note is
+                        // commentary on them. Reading order puts the thing before what is said about
+                        // it, and it keeps the fields anchored under the photo as the notes grow.
+                        //
+                        .when_some(notes, |split, notes| {
+                            split.child(
+                                resizable_panel()
+                                    .size(px(180.))
+                                    .size_range(notes_range)
+                                    .child(notes),
+                            )
+                        }),
+                ),
             )
             .into_any_element()
     }

--- a/crates/workspace/src/panels/details.rs
+++ b/crates/workspace/src/panels/details.rs
@@ -1,4 +1,5 @@
 use std::cell::Cell;
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
 
@@ -14,7 +15,7 @@ use gpui_component::{
     table::TableState,
 };
 use preview::{can_preview, thumb};
-use table::{QrateTableDelegate, Selection, TableChanged, TableStateHandle};
+use table::{QrateTableDelegate, TableChanged, TableStateHandle};
 
 use crate::BottomDockCrop;
 use crate::panel_registry::PanelMeta;
@@ -58,9 +59,14 @@ pub struct DetailsPanel {
     /// The field editor, shared across whichever field is open — the same one-per-panel
     /// arrangement the grid uses for its cell editor.
     editor: Entity<InputState>,
-    /// `(source_row, data_col)` of the field being edited, in the grid's own coordinates so a
-    /// filter change between opening and committing can't redirect the write.
-    editing: Option<(usize, usize)>,
+    /// `(source_rows, data_col)` of the field being edited, in the grid's own coordinates so a
+    /// filter change between opening and committing can't redirect the write. Several rows when
+    /// the field belongs to a bundle: one edit box writing the same value down the selection.
+    editing: Option<(Vec<usize>, usize)>,
+    /// Which of the selected items the preview stack is showing, and whether the pointer is over
+    /// it — the step arrows only exist while it is, so they never cover the photo at rest.
+    stack: usize,
+    stack_hover: bool,
     /// Commits the open field on Enter or when the editor loses focus.
     _editor_sub: Subscription,
     /// Window-space rect of the field row being edited, and of the scrolling field list the
@@ -107,6 +113,8 @@ impl DetailsPanel {
             _crop_sub: cx.observe_global::<BottomDockCrop>(|_this: &mut Self, cx| cx.notify()),
             editor,
             editing: None,
+            stack: 0,
+            stack_hover: false,
             _editor_sub,
             anchor: Rc::default(),
             viewport: Rc::new(Cell::new(Bounds::default())),
@@ -118,16 +126,35 @@ impl DetailsPanel {
         this
     }
 
-    /// The file the selected row links to, which is both what the preview frame draws and what the
+    /// The selected items as source rows in view order — what the whole panel is about, and the
+    /// same list the grid, the gallery and the status bar count.
+    fn picked(&self, cx: &App) -> Vec<usize> {
+        self.state
+            .as_ref()
+            .and_then(|w| w.upgrade())
+            .map(|s| s.read(cx).delegate().selected_source_rows())
+            .unwrap_or_default()
+    }
+
+    /// The item the preview is showing: the stack's front card. Clamped rather than remembered, so
+    /// stepping to the fifth of five and then selecting two doesn't leave the preview blank.
+    fn front(&self, cx: &App) -> Option<usize> {
+        let picked = self.picked(cx);
+        picked
+            .get(self.stack.min(picked.len().checked_sub(1)?))
+            .copied()
+    }
+
+    /// The file the front item links to, which is both what the preview frame draws and what the
     /// transport would play.
     fn selected_file(&self, cx: &App) -> Option<PathBuf> {
         let state = self.state.as_ref()?.upgrade()?;
-        let delegate = state.read(cx).delegate();
-        let row = match delegate.selection()? {
-            Selection::Cell { row, .. } | Selection::Row(row) => row,
-            Selection::Column(_) => return None,
-        };
-        delegate.row_image(row).map(Path::to_path_buf)
+        let row = self.front(cx)?;
+        state
+            .read(cx)
+            .delegate()
+            .row_image(row)
+            .map(Path::to_path_buf)
     }
 
     /// Point the transport at whatever is selected now. A no-op while the selection stays on the
@@ -159,18 +186,20 @@ impl DetailsPanel {
     ) {
         // Whatever was open loses focus rather than being silently dropped.
         self.commit(cx);
-        let located = self.state.as_ref().and_then(|w| w.upgrade()).and_then(|s| {
-            let delegate = s.read(cx).delegate();
-            let row = match delegate.selection()? {
-                Selection::Cell { row, .. } | Selection::Row(row) => row,
-                Selection::Column(_) => return None,
-            };
-            Some((row, delegate.data_col(header)?))
-        });
-        let Some(at) = located else {
+        let rows = self.picked(cx);
+        let located = self
+            .state
+            .as_ref()
+            .and_then(|w| w.upgrade())
+            .and_then(|s| s.read(cx).delegate().data_col(header))
+            .filter(|_| !rows.is_empty());
+        let Some(col) = located else {
             log::warn!("details: no column named {header} to edit");
             return;
         };
+        // The rows are captured here, not read back at commit: the write must land on the items
+        // the archivist was looking at when they started typing, whatever the grid does meanwhile.
+        let at = (rows, col);
         self.editing = Some(at);
         // Re-measured for the new field; the box renders on the frame after the capture.
         self.anchor.set(None);
@@ -181,15 +210,32 @@ impl DetailsPanel {
         cx.notify();
     }
 
+    /// Move the preview stack one item along, wrapping at both ends so a bundle can be walked in
+    /// either direction without hunting for the end of it.
+    fn step_stack(&mut self, forward: bool, cx: &mut Context<Self>) {
+        let count = self.picked(cx).len().max(1);
+        let at = self.stack.min(count - 1);
+        self.stack = match forward {
+            true => (at + 1) % count,
+            false => (at + count - 1) % count,
+        };
+        self.retarget(cx);
+        cx.notify();
+    }
+
     /// Write the open field back through the grid's own mutation path, so dirty-tracking,
     /// validation and undo stay single-sourced. Clearing `editing` first keeps the `TableChanged`
     /// this provokes from re-entering as a second commit.
     fn commit(&mut self, cx: &mut Context<Self>) {
-        let Some((row, col)) = self.editing.take() else {
+        let Some((rows, col)) = self.editing.take() else {
             return;
         };
         let value = self.editor.read(cx).value().clone();
-        table::write_cell(row, col, value, cx);
+        // One batch, so setting a field across a bundle is a single undo step — and `apply_edit`
+        // drops the rows whose text this didn't change, so committing an untouched shared field
+        // costs nothing.
+        let cells = rows.into_iter().map(|row| (row, col, value.clone()));
+        table::write_cells(cells.collect(), cx);
         cx.notify();
     }
 
@@ -197,7 +243,7 @@ impl DetailsPanel {
     /// clamped to the field list. `None` until the field has measured itself, one frame after the
     /// click.
     fn field_editor(&self, window: &mut Window, cx: &mut Context<Self>) -> Option<AnyElement> {
-        self.editing?;
+        self.editing.as_ref()?;
         let anchor = self.anchor.get()?;
         let within = self.editor_area(window);
         let (box_el, _) = table::editor_box(&self.editor, anchor, within, window, cx);
@@ -398,18 +444,83 @@ fn render_image_frame(
         .into_any_element()
 }
 
+/// One of the preview stack's step arrows, pinned to the edge its chevron points at and centred
+/// down the card. Full-height flex rather than a top offset: the pane is a height the user drags,
+/// so there is no fixed centre to hardcode.
+fn step(
+    id: &'static str,
+    left: bool,
+    on_click: impl Fn(&ClickEvent, &mut Window, &mut App) + 'static,
+) -> AnyElement {
+    div()
+        .absolute()
+        .top_0()
+        .bottom_0()
+        .map(|side| match left {
+            true => side.left(px(6.)),
+            false => side.right(px(6.)),
+        })
+        .flex()
+        .items_center()
+        .child(
+            Button::new(id)
+                .icon(match left {
+                    true => IconName::ChevronLeft,
+                    false => IconName::ChevronRight,
+                })
+                .ghost()
+                .small()
+                .tooltip(match left {
+                    true => "Previous selected item",
+                    false => "Next selected item",
+                })
+                .on_click(on_click),
+        )
+        .into_any_element()
+}
+
+/// What a bundle of items has to say about each column: the value when they agree, and how many
+/// distinct values there are when they don't. Display order, so it lines up with the grid.
+///
+/// A field that reads `Mixed` is still editable — typing into it sets that value on every selected
+/// item, which is the whole reason to select several rows before touching a field.
+fn shared_fields(
+    delegate: &QrateTableDelegate,
+    picked: &[usize],
+) -> Vec<(SharedString, SharedString, bool)> {
+    let Some((&first, rest)) = picked.split_first() else {
+        return Vec::new();
+    };
+    let base = delegate.row_fields(first);
+    let mut distinct: Vec<HashSet<SharedString>> = base
+        .iter()
+        .map(|(_, value)| HashSet::from([value.clone()]))
+        .collect();
+    for &row in rest {
+        for (ix, (_, value)) in delegate.row_fields(row).into_iter().enumerate() {
+            if let Some(values) = distinct.get_mut(ix) {
+                values.insert(value);
+            }
+        }
+    }
+    base.into_iter()
+        .zip(distinct)
+        .map(|((key, value), values)| match values.len() {
+            1 => (key, value, false),
+            n => (key, format!("Mixed ({n} values)").into(), true),
+        })
+        .collect()
+}
+
 impl Render for DetailsPanel {
     fn render(&mut self, window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        let selection = self.state.as_ref().and_then(|w| w.upgrade()).and_then(|s| {
-            let state = s.read(cx);
-            let row = match state.delegate().selection()? {
-                Selection::Cell { row, .. } | Selection::Row(row) => row,
-                // A whole-column selection has no single row to detail.
-                Selection::Column(_) => return None,
-            };
-            let delegate = state.delegate();
-            let image = delegate.row_image(row).map(Path::to_path_buf);
-            Some((delegate.row_fields(row), image))
+        let picked = self.picked(cx);
+        let front = self.front(cx);
+        let count = picked.len();
+        let selection = self.state.as_ref().and_then(|w| w.upgrade()).map(|s| {
+            let delegate = s.read(cx).delegate();
+            let image = front.and_then(|row| delegate.row_image(row).map(Path::to_path_buf));
+            (shared_fields(delegate, &picked), image)
         });
 
         // Compact: this dock is one the user drags narrow, and the full-width scrubber would push
@@ -427,19 +538,45 @@ impl Render for DetailsPanel {
             == crate::ViewMode::Gallery;
 
         let Some((fields, image_path)) = selection.filter(|(f, _)| !f.is_empty()) else {
+            // Says what this panel is for and how to fill it, rather than only reporting that it
+            // is empty — the multi-select gesture is the one thing here nobody discovers by luck.
             return div()
                 .size_full()
-                .p_3()
+                .flex()
+                .flex_col()
+                .items_center()
+                .justify_center()
+                .gap_2()
+                .p_6()
+                .text_center()
+                .child(
+                    gpui_component::Icon::new(IconName::LayoutDashboard)
+                        .size_6()
+                        .text_color(cx.theme().muted_foreground.opacity(0.7)),
+                )
+                .child(div().text_sm().child("Nothing selected"))
+                .child(
+                    div()
+                        .max_w(px(190.))
+                        .text_xs()
+                        .text_color(cx.theme().muted_foreground)
+                        .child(format!(
+                            "Select a row or a thumbnail to see its fields here. Hold {} to pick several.",
+                            match cfg!(target_os = "macos") {
+                                true => "⌘",
+                                false => "Ctrl",
+                            }
+                        )),
+                )
                 .text_color(cx.theme().muted_foreground)
-                .child("No selection")
                 .into_any_element();
         };
 
         // Hand-built attribute list, not `DescriptionList`/`DataTable`: the fields are fixed pairs,
         // and it reads as a list rather than a second grid — alternating rows carry the structure,
         // no borders.
-        let editing_col = self.editing.map(|(_, col)| col);
-        let rows = fields.into_iter().enumerate().map(|(ix, (k, v))| {
+        let editing_col = self.editing.as_ref().map(|(_, col)| *col);
+        let rows = fields.into_iter().enumerate().map(|(ix, (k, v, mixed))| {
             // Guarded on `editing_col`: `data_col` is a linear scan of every column, and this runs
             // per row on every render — including the scroll ticks that dirty the whole panel.
             let open = editing_col.is_some()
@@ -484,9 +621,22 @@ impl Render for DetailsPanel {
                         // alone would cut the text off mid-word with nothing to say it had.
                         .line_clamp(VALUE_LINE_CLAMP)
                         .text_ellipsis()
+                        // A mixed field shows what the items disagree about but seeds the editor
+                        // empty: `Mixed (3 values)` is a summary, and committing it as text would
+                        // write that literal string onto every item.
+                        .when(mixed, |value| {
+                            value.italic().text_color(cx.theme().muted_foreground)
+                        })
                         .on_click(cx.listener({
-                            let (k, v) = (k.clone(), v.clone());
-                            move |this, _, window, cx| this.edit_field(&k, &v, window, cx)
+                            let (k, seed) = (
+                                k.clone(),
+                                if mixed {
+                                    SharedString::default()
+                                } else {
+                                    v.clone()
+                                },
+                            );
+                            move |this, _, window, cx| this.edit_field(&k, &seed, window, cx)
                         }))
                         .child(v)
                         // The editor floats over the field rather than replacing it in the row, so
@@ -561,12 +711,99 @@ impl Render for DetailsPanel {
                                 .size(px(image_height))
                                 .size_range(px(80.)..px(600.))
                                 .p_3()
-                                .child(render_image_frame(
-                                    image_path,
-                                    self.caption.clone(),
-                                    transport,
-                                    cx,
-                                )),
+                                // One item is a plain frame. Several are a stack of offset cards
+                                // with the front one live: the bundle keeps a slot per item —
+                                // including an item with no file, which shows its placeholder
+                                // rather than being skipped — so stepping through is a walk over
+                                // the selection, not over the subset that happens to have photos.
+                                .map(|pane| match count > 1 {
+                                    false => pane.child(render_image_frame(
+                                        image_path,
+                                        self.caption.clone(),
+                                        transport,
+                                        cx,
+                                    )),
+                                    true => pane.child(
+                                        div()
+                                            .id("details-stack")
+                                            .relative()
+                                            .size_full()
+                                            .on_hover(cx.listener(|this, over: &bool, _, cx| {
+                                                this.stack_hover = *over;
+                                                cx.notify();
+                                            }))
+                                            .child(
+                                                div()
+                                                    .absolute()
+                                                    .left(px(14.))
+                                                    .right_0()
+                                                    .top(px(10.))
+                                                    .bottom_0()
+                                                    .rounded(cx.theme().radius)
+                                                    .border_1()
+                                                    .border_color(cx.theme().border)
+                                                    .bg(cx.theme().muted),
+                                            )
+                                            .child(
+                                                div()
+                                                    .absolute()
+                                                    .left(px(7.))
+                                                    .right(px(7.))
+                                                    .top(px(5.))
+                                                    .bottom(px(5.))
+                                                    .rounded(cx.theme().radius)
+                                                    .border_1()
+                                                    .border_color(cx.theme().border)
+                                                    .bg(cx.theme().background),
+                                            )
+                                            .child(
+                                                div()
+                                                    .absolute()
+                                                    .left_0()
+                                                    .right(px(14.))
+                                                    .top_0()
+                                                    .bottom(px(10.))
+                                                    .child(render_image_frame(
+                                                        image_path,
+                                                        self.caption.clone(),
+                                                        transport,
+                                                        cx,
+                                                    ))
+                                                    .when(self.stack_hover, |front| {
+                                                        front
+                                                            .child(step(
+                                                                "details-stack-prev",
+                                                                true,
+                                                                cx.listener(|this, _, _, cx| {
+                                                                    this.step_stack(false, cx)
+                                                                }),
+                                                            ))
+                                                            .child(step(
+                                                                "details-stack-next",
+                                                                false,
+                                                                cx.listener(|this, _, _, cx| {
+                                                                    this.step_stack(true, cx)
+                                                                }),
+                                                            ))
+                                                    })
+                                                    .child(
+                                                        div()
+                                                            .absolute()
+                                                            .bottom_0()
+                                                            .right_0()
+                                                            .px_1()
+                                                            .rounded(cx.theme().radius)
+                                                            .bg(cx.theme().background.opacity(0.7))
+                                                            .text_xs()
+                                                            .text_color(cx.theme().muted_foreground)
+                                                            .child(format!(
+                                                                "{} of {count}",
+                                                                self.stack.min(count - 1) + 1
+                                                            )),
+                                                    ),
+                                            ),
+                                    ),
+                                }),
                         )
                     })
                     .child(
@@ -592,6 +829,22 @@ impl Render for DetailsPanel {
                                     .absolute()
                                     .size_full()
                                 })
+                                // Says how many items the fields below speak for, and warns that
+                                // typing into one writes down the whole bundle — before the edit,
+                                // not after it.
+                                .when(count > 1, |list| {
+                                    list.child(
+                                        div()
+                                            .flex()
+                                            .items_center()
+                                            .justify_between()
+                                            .pb_1p5()
+                                            .text_xs()
+                                            .text_color(cx.theme().muted_foreground)
+                                            .child(format!("{count} items · shared fields"))
+                                            .child("edits apply to all"),
+                                    )
+                                })
                                 .child(
                                     div()
                                         .size_full()
@@ -611,6 +864,30 @@ impl Render for DetailsPanel {
                                                 .children(rows),
                                         ),
                                 )
+                                .when(count > 1, |list| {
+                                    list.child(
+                                        div()
+                                            .flex()
+                                            .gap_1p5()
+                                            .pt_2()
+                                            .child(
+                                                Button::new("details-copy-rows")
+                                                    .label(format!("Copy {count} rows"))
+                                                    .small()
+                                                    .flex_1()
+                                                    .on_click(|_, _, cx| table::copy_selection(cx)),
+                                            )
+                                            .child(
+                                                Button::new("details-clear-selection")
+                                                    .label("Clear")
+                                                    .ghost()
+                                                    .small()
+                                                    .on_click(|_, _, cx| {
+                                                        table::clear_selection(cx)
+                                                    }),
+                                            ),
+                                    )
+                                })
                                 .children(self.field_editor(window, cx)),
                         ),
                     ),
@@ -718,12 +995,71 @@ mod tests {
                     rows: vec![
                         vec!["Film".into(), "one".into()],
                         vec!["Video".into(), "two".into()],
+                        // Shares a Medium with row 0 but not a Title, so a selection of the two
+                        // has one agreed field and one mixed.
+                        vec!["Film".into(), "three".into()],
                     ],
                     values: Default::default(),
                 },
             });
         });
         cx.add_window_view(table::TablePanel::new);
+    }
+
+    /// A bundle reports what its items agree on and counts what they don't, and typing into a
+    /// mixed field sets it on every one of them — as a single undo step, so a bulk edit is one
+    /// mistake to take back rather than five.
+    #[gpui::test]
+    fn a_mixed_field_edits_every_selected_item_as_one_step(cx: &mut TestAppContext) {
+        project_with_table(cx);
+        let state = cx.update(|cx| {
+            cx.try_global::<table::TableStateHandle>()
+                .and_then(|h| h.0.upgrade())
+                .expect("the table panel publishes its state handle")
+        });
+        let (panel, cx) = cx.add_window_view(DetailsPanel::new);
+        // Source rows 0 and 2: both Film, titled "one" and "three".
+        state.update(cx, |state, cx| {
+            state.delegate_mut().select_only_row(0);
+            state.delegate_mut().toggle_row(2);
+            cx.notify();
+        });
+
+        panel.update_in(cx, |panel, window, cx| {
+            let fields = state.read(cx).delegate();
+            let fields = super::shared_fields(fields, &panel.picked(cx));
+            assert_eq!(
+                fields,
+                vec![
+                    ("Medium".into(), "Film".into(), false),
+                    ("Title".into(), "Mixed (2 values)".into(), true),
+                ]
+            );
+
+            panel.edit_field(&"Title".into(), &"".into(), window, cx);
+            assert_eq!(
+                panel.editing,
+                Some((vec![0, 2], 1)),
+                "the write is aimed at both selected items"
+            );
+            panel
+                .editor
+                .update(cx, |editor, cx| editor.set_value("retitled", window, cx));
+            panel.commit(cx);
+        });
+
+        let titles = |cx: &mut VisualTestContext| {
+            state.read_with(cx, |s, _| {
+                (0..3)
+                    .map(|row| s.delegate().cell(row, 1).cloned().unwrap_or_default())
+                    .collect::<Vec<_>>()
+            })
+        };
+        assert_eq!(titles(cx), vec!["retitled", "two", "retitled"]);
+
+        // One undo, not two: the batch is what makes a bundle edit safe to try.
+        cx.update(|_, cx| table::history_step(false, cx));
+        assert_eq!(titles(cx), vec!["one", "two", "three"]);
     }
 
     /// The DoD: a field edited in the panel lands in the grid, and undo — the grid's own history,
@@ -743,14 +1079,14 @@ mod tests {
 
         panel.update_in(cx, |panel, window, cx| {
             panel.edit_field(&"Title".into(), &"two".into(), window, cx);
-            assert_eq!(panel.editing, Some((1, 1)), "Title is data column 1");
+            assert_eq!(panel.editing, Some((vec![1], 1)), "Title is data column 1");
             panel.editor.update(cx, |editor, cx| {
                 editor.set_value("two, revised", window, cx)
             });
             panel.commit(cx);
 
             panel.edit_field(&"Medium".into(), &"Video".into(), window, cx);
-            assert_eq!(panel.editing, Some((1, 0)), "Medium is data column 0");
+            assert_eq!(panel.editing, Some((vec![1], 0)), "Medium is data column 0");
             panel.editing = None;
         });
 

--- a/crates/workspace/src/views/gallery.rs
+++ b/crates/workspace/src/views/gallery.rs
@@ -9,7 +9,7 @@
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{ActiveTheme, table::TableState};
+use gpui_component::{ActiveTheme, menu::ContextMenuExt as _, table::TableState};
 use preview::{can_preview, thumb};
 use table::QrateTableDelegate;
 
@@ -176,6 +176,20 @@ fn card(
         // follows, which is what keeps every view on one cursor. Double click is the deliberate
         // "look at this one" — the photo takes over the centre, leaving the docked panels
         // readable beside it, which is why it opens at `Centre` and not `Workspace`.
+        // Right-click selects the card unless it is already part of the selection — the same rule
+        // the grid's cells follow, so aiming at a bundle to act on it can't be what destroys it.
+        .on_mouse_down(MouseButton::Right, {
+            let state = state.clone();
+            move |_, _window, cx| {
+                state.update(cx, |state, cx| {
+                    if !state.delegate().is_row_selected(source) {
+                        state.delegate_mut().select_only_row(source);
+                        cx.emit(table::TableChanged);
+                        cx.notify();
+                    }
+                });
+            }
+        })
         .on_mouse_down(
             MouseButton::Left,
             move |ev: &MouseDownEvent, _window, cx| {
@@ -207,5 +221,10 @@ fn card(
                 }
             },
         )
+        // Last: `context_menu` wraps the element rather than extending it, so anything chained
+        // after this would land on the wrapper instead of the card.
+        .context_menu(move |menu, window, cx| {
+            table::context_menu(table::MenuTarget::Row(source), menu, window, cx)
+        })
         .into_any_element()
 }

--- a/crates/workspace/src/views/gallery.rs
+++ b/crates/workspace/src/views/gallery.rs
@@ -9,29 +9,35 @@
 
 use gpui::prelude::FluentBuilder as _;
 use gpui::*;
-use gpui_component::{ActiveTheme, menu::ContextMenuExt as _, table::TableState};
+use gpui_component::{
+    ActiveTheme, Icon, IconName, Sizable as _, menu::ContextMenuExt as _, table::TableState,
+};
 use preview::{can_preview, thumb};
 use table::QrateTableDelegate;
 
-/// Card geometry. The width is the slider's business — wide enough to tell two scans of the same
-/// document apart at the top of its range, small enough at the bottom that a whole box of prints
-/// is on screen at once. Height trails the width by the caption line.
-pub(super) const CARD_MIN: f32 = 110.;
-pub(super) const CARD_MAX: f32 = 230.;
-pub(super) const CARD_DEFAULT: f32 = 168.;
-const CAPTION_H: f32 = 16.;
+/// Card geometry. The slider sets how many cards go in a row, not how wide one is: the row always
+/// spans the view, so cards divide whatever width the panel has between them and there is no
+/// leftover gutter to make the grid look off-centre. Height follows the width — a square frame
+/// plus the caption line under it.
+///
+/// Two per row is as coarse as it is worth going; past twelve a card is smaller than the caption
+/// under it.
+pub(super) const COLS_MIN: f32 = 2.;
+pub(super) const COLS_MAX: f32 = 12.;
+pub(super) const COLS_DEFAULT: f32 = 5.;
 const GAP: f32 = 8.;
+const PAD: f32 = 8.;
 
-/// Project-scoped thumbnail size, in pixels.
-pub(super) const THUMB_SIZE_KEY: &str = "gallery_thumb_size";
+/// Project-scoped cards per row.
+pub(super) const COLUMNS_KEY: &str = "gallery_columns";
 
-/// The card width in force, clamped to the slider's range so a hand-edited setting can't produce a
-/// wall of one-pixel cards or a single card per screen.
-pub(super) fn card_width(cx: &App) -> f32 {
-    settings::effective_text(THUMB_SIZE_KEY, cx)
+/// Cards per row, clamped to the slider's range so a hand-edited setting can't produce a wall of
+/// one-pixel cards or a division by zero.
+pub(super) fn columns(cx: &App) -> usize {
+    settings::effective_text(COLUMNS_KEY, cx)
         .parse::<f32>()
-        .unwrap_or(CARD_DEFAULT)
-        .clamp(CARD_MIN, CARD_MAX)
+        .unwrap_or(COLS_DEFAULT)
+        .clamp(COLS_MIN, COLS_MAX) as usize
 }
 
 /// The gallery body. `width` is the measured body width, for the column count.
@@ -48,31 +54,12 @@ pub(super) fn card_width(cx: &App) -> f32 {
 pub(super) fn render(
     state: Option<Entity<TableState<QrateTableDelegate>>>,
     width: Pixels,
-    notes_only: bool,
+    focus: &FocusHandle,
     cx: &mut App,
 ) -> AnyElement {
-    // Rows the gallery draws: everything visible, or only what has been annotated. Narrowed here
-    // rather than through the column filters — "has a note" is not a cell value, and pushing it
-    // into `visible_rows` would make the grid and the status bar disagree with the table.
-    let rows: Vec<usize> = state.as_ref().map_or_else(Vec::new, |state| {
-        let delegate = state.read(cx).delegate();
-        delegate
-            .visible()
-            .iter()
-            .enumerate()
-            .filter(|(_, source)| {
-                !notes_only
-                    || diagnostics::Diagnostics::note_count(
-                        diagnostics::DATASET_MAIN,
-                        Some(**source),
-                        None,
-                        cx,
-                    ) > 0
-            })
-            .map(|(view, _)| view)
-            .collect()
-    });
-    let count = rows.len();
+    let count = state
+        .as_ref()
+        .map_or(0, |state| state.read(cx).delegate().visible().len());
     let (Some(state), 1..) = (state, count) else {
         return div()
             .size_full()
@@ -85,8 +72,11 @@ pub(super) fn render(
             .into_any_element();
     };
 
-    let card_w = card_width(cx);
-    let cols = (f32::from(width) / (card_w + GAP)).floor().max(1.) as usize;
+    // The row is the panel minus its padding, split evenly with a gap between each pair. Cards get
+    // the width rather than choosing it, so the grid meets both edges at any panel size.
+    let cols = columns(cx);
+    let card_w = ((f32::from(width) - 2. * PAD - GAP * (cols - 1) as f32) / cols as f32).max(1.);
+    let focus = focus.clone();
     uniform_list(
         "gallery",
         count.div_ceil(cols),
@@ -98,8 +88,8 @@ pub(super) fn render(
                         .gap(px(GAP))
                         .pb(px(GAP))
                         .children((0..cols).filter_map(|offset| {
-                            let slot = band * cols + offset;
-                            rows.get(slot).map(|&view| card(&state, view, card_w, cx))
+                            let view = band * cols + offset;
+                            (view < count).then(|| card(&state, view, card_w, &focus, cx))
                         }))
                 })
                 .collect()
@@ -116,6 +106,7 @@ fn card(
     state: &Entity<TableState<QrateTableDelegate>>,
     view: usize,
     card_w: f32,
+    focus: &FocusHandle,
     cx: &mut App,
 ) -> AnyElement {
     let delegate = state.read(cx).delegate();
@@ -133,74 +124,74 @@ fn card(
     // A scan of a twelve-page ledger and a scan of one photograph look identical at thumbnail
     // size. `page_count` is cheap for everything that isn't a document and cached beyond that.
     let pages = path.as_deref().map_or(1, preview::page_count);
-    // What the item has been annotated with. The count only — the text lives in Details' Notes
-    // sub-panel, so the tile stays a picture rather than becoming a card of prose.
+    // What the item has been annotated with, wherever on the row it was filed. The count only —
+    // the text lives in Details' Notes sub-panel, so the tile stays a picture rather than becoming
+    // a card of prose.
     let notes =
-        diagnostics::Diagnostics::note_count(diagnostics::DATASET_MAIN, Some(source), None, cx);
+        diagnostics::Diagnostics::notes_in_row(diagnostics::DATASET_MAIN, source, cx).count();
 
     // Only a decodable image is worth opening; a placeholder card has nothing to zoom into, so
     // clicking one selects the row and leaves the grid up.
     let viewable = path.clone().filter(|path| can_preview(path));
 
+    // A count over the picture, dark enough to read against a blown-out scan and a black one
+    // alike — so the corner markers are legible whatever the thumbnail underneath happens to be.
+    // Icon plus bare number: at 110px the word "pages" is most of the tile's width.
+    let radius = cx.theme().radius;
+    let badge = move |icon: IconName, count: usize| {
+        div()
+            .absolute()
+            .right_1()
+            .flex()
+            .items_center()
+            .gap_1()
+            .px_1()
+            .rounded(radius)
+            .bg(black().opacity(0.6))
+            .text_xs()
+            .text_color(white())
+            .child(Icon::new(icon).xsmall().text_color(white()))
+            .child(count.to_string())
+    };
+
     let state = state.clone();
     div()
         .id(("gallery-card", view))
         .w(px(card_w))
-        .h(px(card_w + CAPTION_H))
         .flex()
         .flex_col()
         .gap_1()
         .p_1()
         .cursor_pointer()
         .rounded(cx.theme().radius)
-        // The same pair the grid paints a selected row with, so one item picked in the gallery and
-        // the same item picked in the table are recognisably the same state.
-        .border_1()
-        .border_color(match selected {
-            true => cx.theme().table_active_border,
-            false => cx.theme().border,
-        })
+        // The halo behind a ringed frame: the same fill the grid paints a selected row with, so one
+        // item picked in the gallery and the same item picked in the table read as one state.
         .when(selected, |card| card.bg(cx.theme().table_active))
-        .when(!selected, |card| {
-            card.hover(|card| card.bg(cx.theme().accent))
-        })
         .child(
+            // Square, so a wall of cards is a grid rather than a ragged edge — the thumbnail is
+            // letterboxed inside it and keeps its own proportions.
             div()
                 .relative()
-                .flex_1()
-                .min_h_0()
+                .h(px(card_w - 8.))
                 .overflow_hidden()
+                .rounded(cx.theme().radius)
+                .bg(cx.theme().muted)
+                .border_1()
+                .border_color(cx.theme().border)
+                .when(selected, |frame| {
+                    frame
+                        .border_2()
+                        .border_color(cx.theme().table_active_border)
+                })
+                .when(!selected, |frame| {
+                    frame.hover(|frame| frame.border_color(cx.theme().ring))
+                })
                 .child(thumb(path.as_deref(), preview::CARD, cx))
                 .when(pages > 1, |frame| {
-                    frame.child(
-                        div()
-                            .absolute()
-                            .top_1()
-                            .right_1()
-                            .px_1()
-                            .rounded(cx.theme().radius)
-                            .bg(cx.theme().background.opacity(0.75))
-                            .text_xs()
-                            .text_color(cx.theme().muted_foreground)
-                            .child(format!("{pages} pages")),
-                    )
+                    frame.child(badge(IconName::Copy, pages).top_1())
                 })
                 .when(notes > 0, |frame| {
-                    frame.child(
-                        div()
-                            .absolute()
-                            .bottom_1()
-                            .right_1()
-                            .px_1()
-                            .rounded(cx.theme().radius)
-                            .bg(cx.theme().background.opacity(0.75))
-                            .text_xs()
-                            .text_color(cx.theme().muted_foreground)
-                            .child(match notes {
-                                1 => "1 note".to_string(),
-                                n => format!("{n} notes"),
-                            }),
-                    )
+                    frame.child(badge(IconName::Menu, notes).bottom_1())
                 }),
         )
         .child(
@@ -209,7 +200,10 @@ fn card(
                 .w_full()
                 .text_xs()
                 .truncate()
-                .text_color(cx.theme().muted_foreground)
+                .text_color(match selected {
+                    true => cx.theme().foreground,
+                    false => cx.theme().muted_foreground,
+                })
                 .child(caption),
         )
         // Single click selects and nothing more, so the grid stays browsable: `TablePanel`'s
@@ -231,9 +225,12 @@ fn card(
                 });
             }
         })
-        .on_mouse_down(
-            MouseButton::Left,
-            move |ev: &MouseDownEvent, _window, cx| {
+        .on_mouse_down(MouseButton::Left, {
+            let focus = focus.clone();
+            move |ev: &MouseDownEvent, window, cx| {
+                // Picking a card puts focus on the centre panel, which is what makes Escape mean
+                // "drop this selection" — the cards themselves take no focus of their own.
+                window.focus(&focus, cx);
                 // The same three gestures the grid answers to, so a selection built in one view is
                 // built the same way in the other.
                 match (ev.modifiers.secondary(), ev.modifiers.shift) {
@@ -260,8 +257,8 @@ fn card(
                 if let Some(path) = viewable.clone() {
                     crate::viewer::open_viewer(path, crate::ViewerScope::Centre, cx);
                 }
-            },
-        )
+            }
+        })
         // Last: `context_menu` wraps the element rather than extending it, so anything chained
         // after this would land on the wrapper instead of the card.
         .context_menu(move |menu, window, cx| {

--- a/crates/workspace/src/views/gallery.rs
+++ b/crates/workspace/src/views/gallery.rs
@@ -48,11 +48,31 @@ pub(super) fn card_width(cx: &App) -> f32 {
 pub(super) fn render(
     state: Option<Entity<TableState<QrateTableDelegate>>>,
     width: Pixels,
+    notes_only: bool,
     cx: &mut App,
 ) -> AnyElement {
-    let count = state
-        .as_ref()
-        .map_or(0, |state| state.read(cx).delegate().visible().len());
+    // Rows the gallery draws: everything visible, or only what has been annotated. Narrowed here
+    // rather than through the column filters — "has a note" is not a cell value, and pushing it
+    // into `visible_rows` would make the grid and the status bar disagree with the table.
+    let rows: Vec<usize> = state.as_ref().map_or_else(Vec::new, |state| {
+        let delegate = state.read(cx).delegate();
+        delegate
+            .visible()
+            .iter()
+            .enumerate()
+            .filter(|(_, source)| {
+                !notes_only
+                    || diagnostics::Diagnostics::note_count(
+                        diagnostics::DATASET_MAIN,
+                        Some(**source),
+                        None,
+                        cx,
+                    ) > 0
+            })
+            .map(|(view, _)| view)
+            .collect()
+    });
+    let count = rows.len();
     let (Some(state), 1..) = (state, count) else {
         return div()
             .size_full()
@@ -78,8 +98,8 @@ pub(super) fn render(
                         .gap(px(GAP))
                         .pb(px(GAP))
                         .children((0..cols).filter_map(|offset| {
-                            let view = band * cols + offset;
-                            (view < count).then(|| card(&state, view, card_w, cx))
+                            let slot = band * cols + offset;
+                            rows.get(slot).map(|&view| card(&state, view, card_w, cx))
                         }))
                 })
                 .collect()
@@ -113,6 +133,10 @@ fn card(
     // A scan of a twelve-page ledger and a scan of one photograph look identical at thumbnail
     // size. `page_count` is cheap for everything that isn't a document and cached beyond that.
     let pages = path.as_deref().map_or(1, preview::page_count);
+    // What the item has been annotated with. The count only — the text lives in Details' Notes
+    // sub-panel, so the tile stays a picture rather than becoming a card of prose.
+    let notes =
+        diagnostics::Diagnostics::note_count(diagnostics::DATASET_MAIN, Some(source), None, cx);
 
     // Only a decodable image is worth opening; a placeholder card has nothing to zoom into, so
     // clicking one selects the row and leaves the grid up.
@@ -159,6 +183,23 @@ fn card(
                             .text_xs()
                             .text_color(cx.theme().muted_foreground)
                             .child(format!("{pages} pages")),
+                    )
+                })
+                .when(notes > 0, |frame| {
+                    frame.child(
+                        div()
+                            .absolute()
+                            .bottom_1()
+                            .right_1()
+                            .px_1()
+                            .rounded(cx.theme().radius)
+                            .bg(cx.theme().background.opacity(0.75))
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(match notes {
+                                1 => "1 note".to_string(),
+                                n => format!("{n} notes"),
+                            }),
                     )
                 }),
         )

--- a/crates/workspace/src/views/gallery.rs
+++ b/crates/workspace/src/views/gallery.rs
@@ -11,13 +11,28 @@ use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::{ActiveTheme, table::TableState};
 use preview::{can_preview, thumb};
-use table::{QrateTableDelegate, Selection};
+use table::QrateTableDelegate;
 
-/// Card geometry. Wide enough to tell two scans of the same document apart, small enough that a
-/// batch of thirty is on screen at once.
-const CARD_W: f32 = 168.;
-const CARD_H: f32 = 184.;
+/// Card geometry. The width is the slider's business — wide enough to tell two scans of the same
+/// document apart at the top of its range, small enough at the bottom that a whole box of prints
+/// is on screen at once. Height trails the width by the caption line.
+pub(super) const CARD_MIN: f32 = 110.;
+pub(super) const CARD_MAX: f32 = 230.;
+pub(super) const CARD_DEFAULT: f32 = 168.;
+const CAPTION_H: f32 = 16.;
 const GAP: f32 = 8.;
+
+/// Project-scoped thumbnail size, in pixels.
+pub(super) const THUMB_SIZE_KEY: &str = "gallery_thumb_size";
+
+/// The card width in force, clamped to the slider's range so a hand-edited setting can't produce a
+/// wall of one-pixel cards or a single card per screen.
+pub(super) fn card_width(cx: &App) -> f32 {
+    settings::effective_text(THUMB_SIZE_KEY, cx)
+        .parse::<f32>()
+        .unwrap_or(CARD_DEFAULT)
+        .clamp(CARD_MIN, CARD_MAX)
+}
 
 /// The gallery body. `width` is the measured body width, for the column count.
 ///
@@ -50,7 +65,8 @@ pub(super) fn render(
             .into_any_element();
     };
 
-    let cols = (f32::from(width) / (CARD_W + GAP)).floor().max(1.) as usize;
+    let card_w = card_width(cx);
+    let cols = (f32::from(width) / (card_w + GAP)).floor().max(1.) as usize;
     uniform_list(
         "gallery",
         count.div_ceil(cols),
@@ -63,7 +79,7 @@ pub(super) fn render(
                         .pb(px(GAP))
                         .children((0..cols).filter_map(|offset| {
                             let view = band * cols + offset;
-                            (view < count).then(|| card(&state, view, cx))
+                            (view < count).then(|| card(&state, view, card_w, cx))
                         }))
                 })
                 .collect()
@@ -76,10 +92,15 @@ pub(super) fn render(
 
 /// One row's card: its resolved image (or a placeholder honest about what the file is) over its
 /// first non-empty field as a caption, ringed while it holds the selection.
-fn card(state: &Entity<TableState<QrateTableDelegate>>, view: usize, cx: &mut App) -> AnyElement {
+fn card(
+    state: &Entity<TableState<QrateTableDelegate>>,
+    view: usize,
+    card_w: f32,
+    cx: &mut App,
+) -> AnyElement {
     let delegate = state.read(cx).delegate();
     let Some(source) = delegate.source(view) else {
-        return div().w(px(CARD_W)).into_any_element();
+        return div().w(px(card_w)).into_any_element();
     };
     let path = delegate.row_image(source).map(std::path::Path::to_path_buf);
     let caption = delegate
@@ -88,10 +109,10 @@ fn card(state: &Entity<TableState<QrateTableDelegate>>, view: usize, cx: &mut Ap
         .map(|(_, value)| value)
         .find(|value| !value.is_empty())
         .unwrap_or_default();
-    let selected = matches!(
-        delegate.selection(),
-        Some(Selection::Cell { row, .. } | Selection::Row(row)) if row == source
-    );
+    let selected = delegate.is_row_selected(source);
+    // A scan of a twelve-page ledger and a scan of one photograph look identical at thumbnail
+    // size. `page_count` is cheap for everything that isn't a document and cached beyond that.
+    let pages = path.as_deref().map_or(1, preview::page_count);
 
     // Only a decodable image is worth opening; a placeholder card has nothing to zoom into, so
     // clicking one selects the row and leaves the grid up.
@@ -100,27 +121,47 @@ fn card(state: &Entity<TableState<QrateTableDelegate>>, view: usize, cx: &mut Ap
     let state = state.clone();
     div()
         .id(("gallery-card", view))
-        .w(px(CARD_W))
-        .h(px(CARD_H))
+        .w(px(card_w))
+        .h(px(card_w + CAPTION_H))
         .flex()
         .flex_col()
         .gap_1()
         .p_1()
         .cursor_pointer()
         .rounded(cx.theme().radius)
+        // The same pair the grid paints a selected row with, so one item picked in the gallery and
+        // the same item picked in the table are recognisably the same state.
         .border_1()
         .border_color(match selected {
-            true => cx.theme().primary,
+            true => cx.theme().table_active_border,
             false => cx.theme().border,
         })
+        .when(selected, |card| card.bg(cx.theme().table_active))
         .when(!selected, |card| {
             card.hover(|card| card.bg(cx.theme().accent))
         })
-        .child(div().flex_1().min_h_0().overflow_hidden().child(thumb(
-            path.as_deref(),
-            preview::CARD,
-            cx,
-        )))
+        .child(
+            div()
+                .relative()
+                .flex_1()
+                .min_h_0()
+                .overflow_hidden()
+                .child(thumb(path.as_deref(), preview::CARD, cx))
+                .when(pages > 1, |frame| {
+                    frame.child(
+                        div()
+                            .absolute()
+                            .top_1()
+                            .right_1()
+                            .px_1()
+                            .rounded(cx.theme().radius)
+                            .bg(cx.theme().background.opacity(0.75))
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(format!("{pages} pages")),
+                    )
+                }),
+        )
         .child(
             div()
                 .flex_none()
@@ -138,7 +179,26 @@ fn card(state: &Entity<TableState<QrateTableDelegate>>, view: usize, cx: &mut Ap
         .on_mouse_down(
             MouseButton::Left,
             move |ev: &MouseDownEvent, _window, cx| {
-                state.update(cx, |state, cx| state.set_selected_row(view, cx));
+                // The same three gestures the grid answers to, so a selection built in one view is
+                // built the same way in the other.
+                match (ev.modifiers.secondary(), ev.modifiers.shift) {
+                    (true, _) => state.update(cx, |state, cx| {
+                        state.delegate_mut().toggle_row(source);
+                        cx.emit(table::TableChanged);
+                        cx.notify();
+                    }),
+                    (false, true) => state.update(cx, |state, cx| {
+                        state.delegate_mut().extend_rows_to(source);
+                        cx.emit(table::TableChanged);
+                        cx.notify();
+                    }),
+                    (false, false) => {
+                        state.update(cx, |state, cx| {
+                            state.delegate_mut().clear_selection();
+                            state.set_selected_row(view, cx);
+                        });
+                    }
+                }
                 if ev.click_count < 2 {
                     return;
                 }

--- a/crates/workspace/src/views/mod.rs
+++ b/crates/workspace/src/views/mod.rs
@@ -14,7 +14,7 @@ mod gallery;
 use gpui::*;
 use gpui_component::table::TableState;
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, Sizable as _,
+    ActiveTheme as _, Icon, IconName, Selectable as _, Sizable as _,
     button::Button,
     dock::{DockArea, Panel, PanelControl, PanelEvent},
     h_flex,
@@ -131,6 +131,10 @@ pub struct ViewsPanel {
     thumb: Entity<SliderState>,
     /// Persists the size as it is dragged, and repaints the cards to match.
     _thumb_sub: Subscription,
+    /// Whether the gallery is narrowed to items carrying a note. Deliberately not persisted: it is
+    /// a lens you pick up to do one pass over a collection, and finding it still on next week
+    /// would read as half the archive having vanished.
+    notes_only: bool,
 }
 
 impl ViewsPanel {
@@ -177,6 +181,7 @@ impl ViewsPanel {
             _viewer_sub: cx.observe_global::<crate::viewer::ActiveViewer>(|_, cx| cx.notify()),
             thumb,
             _thumb_sub,
+            notes_only: false,
         };
         this.bind(cx);
         // Publish before the first render so the View menu works from the moment the window is up.
@@ -374,6 +379,18 @@ impl Render for ViewsPanel {
                                 .px_2()
                                 .pt_1()
                                 .child(
+                                    Button::new("gallery-notes-only")
+                                        .label("Notes only")
+                                        .xsmall()
+                                        .selected(self.notes_only)
+                                        .tooltip("Show only items with notes")
+                                        .on_click(cx.listener(|this, _, _, cx| {
+                                            this.notes_only = !this.notes_only;
+                                            cx.notify();
+                                        })),
+                                )
+                                .child(div().flex_1())
+                                .child(
                                     Icon::new(IconName::LayoutDashboard)
                                         .small()
                                         .text_color(cx.theme().muted_foreground),
@@ -390,6 +407,7 @@ impl Render for ViewsPanel {
                         .child(div().flex_1().min_h_0().child(gallery::render(
                             self.state.as_ref().and_then(WeakEntity::upgrade),
                             self.body_width,
+                            self.notes_only,
                             cx,
                         )))
                         .into_any_element(),

--- a/crates/workspace/src/views/mod.rs
+++ b/crates/workspace/src/views/mod.rs
@@ -14,10 +14,11 @@ mod gallery;
 use gpui::*;
 use gpui_component::table::TableState;
 use gpui_component::{
-    IconName, Sizable as _,
+    ActiveTheme as _, Icon, IconName, Sizable as _,
     button::Button,
     dock::{DockArea, Panel, PanelControl, PanelEvent},
     h_flex,
+    slider::{Slider, SliderEvent, SliderState},
     tab::{Tab, TabBar},
     v_flex,
 };
@@ -125,6 +126,11 @@ pub struct ViewsPanel {
     _changed_sub: Option<Subscription>,
     /// Mounts and unmounts the centre-scoped photo overlay as cards are clicked and dismissed.
     _viewer_sub: Subscription,
+    /// Thumbnail size for the gallery. Owned here rather than in `gallery::render`, which is a
+    /// free function with no state of its own to keep between frames.
+    thumb: Entity<SliderState>,
+    /// Persists the size as it is dragged, and repaints the cards to match.
+    _thumb_sub: Subscription,
 }
 
 impl ViewsPanel {
@@ -134,6 +140,26 @@ impl ViewsPanel {
         cx: &mut Context<Self>,
     ) -> Self {
         let table = cx.new(|cx| TablePanel::new(window, cx));
+        let width = gallery::card_width(cx);
+        // `max` before `min`: each setter re-clamps the current value against the *other* bound as
+        // it stands, and the default max is 100 — so raising the floor to 110 first panics.
+        let thumb = cx.new(|_| {
+            SliderState::new()
+                .max(gallery::CARD_MAX)
+                .min(gallery::CARD_MIN)
+                .step(10.)
+                .default_value(width)
+        });
+        let _thumb_sub = cx.subscribe(&thumb, |_this, _slider, event: &SliderEvent, cx| {
+            let (SliderEvent::Change(value) | SliderEvent::Release(value)) = event;
+            let text = SharedString::from(format!("{}", value.start().round()));
+            if cx.has_global::<settings::project::CurrentProject>() {
+                settings::project::CurrentProject::set_text(gallery::THUMB_SIZE_KEY, text, cx);
+            } else {
+                settings::AppSettings::set_text(gallery::THUMB_SIZE_KEY, text, cx);
+            }
+            cx.notify();
+        });
         let mut this = Self {
             focus_handle: cx.focus_handle(),
             table,
@@ -149,6 +175,8 @@ impl ViewsPanel {
             }),
             _changed_sub: None,
             _viewer_sub: cx.observe_global::<crate::viewer::ActiveViewer>(|_, cx| cx.notify()),
+            thumb,
+            _thumb_sub,
         };
         this.bind(cx);
         // Publish before the first render so the View menu works from the moment the window is up.
@@ -332,11 +360,39 @@ impl Render for ViewsPanel {
                 // chained-builder types meeting in one `match` overflows rustc's stack.
                 .child(match self.view {
                     ViewMode::Table => self.table.clone().into_any_element(),
-                    ViewMode::Gallery => gallery::render(
-                        self.state.as_ref().and_then(WeakEntity::upgrade),
-                        self.body_width,
-                        cx,
-                    ),
+                    // The size control rides above the cards rather than in `toolbar_buttons`,
+                    // which the library restricts to buttons — and it belongs to the gallery, so
+                    // it goes away with it.
+                    ViewMode::Gallery => v_flex()
+                        .size_full()
+                        .child(
+                            h_flex()
+                                .flex_none()
+                                .justify_end()
+                                .items_center()
+                                .gap_2()
+                                .px_2()
+                                .pt_1()
+                                .child(
+                                    Icon::new(IconName::LayoutDashboard)
+                                        .small()
+                                        .text_color(cx.theme().muted_foreground),
+                                )
+                                .child(div().w(px(96.)).child(Slider::new(&self.thumb)))
+                                .child(
+                                    div()
+                                        .w(px(34.))
+                                        .text_xs()
+                                        .text_color(cx.theme().muted_foreground)
+                                        .child(format!("{}px", gallery::card_width(cx).round())),
+                                ),
+                        )
+                        .child(div().flex_1().min_h_0().child(gallery::render(
+                            self.state.as_ref().and_then(WeakEntity::upgrade),
+                            self.body_width,
+                            cx,
+                        )))
+                        .into_any_element(),
                 })
                 // The clicked card's photo, over the grid of thumbnails but under nothing
                 // else — the docked panels stay put, which is the whole point of scoping it

--- a/crates/workspace/src/views/mod.rs
+++ b/crates/workspace/src/views/mod.rs
@@ -11,10 +11,11 @@
 
 mod gallery;
 
+use gpui::prelude::FluentBuilder as _;
 use gpui::*;
 use gpui_component::table::TableState;
 use gpui_component::{
-    ActiveTheme as _, Icon, IconName, Selectable as _, Sizable as _,
+    ActiveTheme as _, Icon, IconName, Sizable as _,
     button::Button,
     dock::{DockArea, Panel, PanelControl, PanelEvent},
     h_flex,
@@ -28,6 +29,10 @@ use crate::ViewerScope;
 
 /// Settings key for the active view, in either scope.
 pub const VIEW_MODE_KEY: &str = "view_mode";
+
+/// Key context of the centre panel, for the keys that act on whatever view is up — Escape to drop
+/// the selection. The grid has its own deeper context, so a key bound to both means the grid's.
+pub const VIEWS_CONTEXT: &str = "ViewsPanel";
 
 #[derive(Copy, Clone, Default, PartialEq, Eq, Debug, serde::Deserialize, schemars::JsonSchema)]
 pub enum ViewMode {
@@ -126,15 +131,11 @@ pub struct ViewsPanel {
     _changed_sub: Option<Subscription>,
     /// Mounts and unmounts the centre-scoped photo overlay as cards are clicked and dismissed.
     _viewer_sub: Subscription,
-    /// Thumbnail size for the gallery. Owned here rather than in `gallery::render`, which is a
-    /// free function with no state of its own to keep between frames.
+    /// Cards per row in the gallery. Owned here rather than in `gallery::render`, which is a free
+    /// function with no state of its own to keep between frames.
     thumb: Entity<SliderState>,
-    /// Persists the size as it is dragged, and repaints the cards to match.
+    /// Persists the count as it is dragged, and repaints the cards to match.
     _thumb_sub: Subscription,
-    /// Whether the gallery is narrowed to items carrying a note. Deliberately not persisted: it is
-    /// a lens you pick up to do one pass over a collection, and finding it still on next week
-    /// would read as half the archive having vanished.
-    notes_only: bool,
 }
 
 impl ViewsPanel {
@@ -144,24 +145,29 @@ impl ViewsPanel {
         cx: &mut Context<Self>,
     ) -> Self {
         let table = cx.new(|cx| TablePanel::new(window, cx));
-        let width = gallery::card_width(cx);
+        let cols = gallery::columns(cx) as f32;
         // `max` before `min`: each setter re-clamps the current value against the *other* bound as
-        // it stands, and the default max is 100 — so raising the floor to 110 first panics.
+        // it stands, and the default min is 0 — so lowering the ceiling first would trap the value.
         let thumb = cx.new(|_| {
             SliderState::new()
-                .max(gallery::CARD_MAX)
-                .min(gallery::CARD_MIN)
-                .step(10.)
-                .default_value(width)
+                .max(gallery::COLS_MAX)
+                .min(gallery::COLS_MIN)
+                .step(1.)
+                .default_value(cols)
         });
         let _thumb_sub = cx.subscribe(&thumb, |_this, _slider, event: &SliderEvent, cx| {
             let (SliderEvent::Change(value) | SliderEvent::Release(value)) = event;
             let text = SharedString::from(format!("{}", value.start().round()));
             if cx.has_global::<settings::project::CurrentProject>() {
-                settings::project::CurrentProject::set_text(gallery::THUMB_SIZE_KEY, text, cx);
+                settings::project::CurrentProject::set_text(gallery::COLUMNS_KEY, text, cx);
             } else {
-                settings::AppSettings::set_text(gallery::THUMB_SIZE_KEY, text, cx);
+                settings::AppSettings::set_text(gallery::COLUMNS_KEY, text, cx);
             }
+            // The slider is drawn in the panel *title*, which the parent `TabPanel` owns and which
+            // does not observe this panel — `cx.notify()` alone would repaint the cards while the
+            // thumb stayed put under the pointer. Dragging it is one deliberate gesture, so a full
+            // redraw is the cheap honest fix, the same trade `switch` makes.
+            cx.refresh_windows();
             cx.notify();
         });
         let mut this = Self {
@@ -181,7 +187,6 @@ impl ViewsPanel {
             _viewer_sub: cx.observe_global::<crate::viewer::ActiveViewer>(|_, cx| cx.notify()),
             thumb,
             _thumb_sub,
-            notes_only: false,
         };
         this.bind(cx);
         // Publish before the first render so the View menu works from the moment the window is up.
@@ -296,8 +301,31 @@ impl Panel for ViewsPanel {
     /// Wrapped in an `h_flex`, which is what keeps the switcher the width of its own tabs. The
     /// title cell is a plain `div` and gpui's default display is *block*, so a bare `TabBar` fills
     /// it — painting the segmented background all the way across to the Find icon.
+    ///
+    /// The gallery's density control rides here rather than in a strip of its own above the cards:
+    /// it belongs to the same row as everything else that says what the centre is showing, and it
+    /// costs the cards no height. `toolbar_buttons` can't hold it — the library restricts that side
+    /// to `Button`s — so it is pushed right by a spacer instead, landing beside the ⋯ menu.
     fn title(&mut self, _w: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
-        h_flex().child(self.switcher(cx))
+        h_flex().w_full().gap_2().child(self.switcher(cx)).when(
+            self.view == ViewMode::Gallery,
+            |title| {
+                title
+                    .child(div().flex_1())
+                    .child(
+                        Icon::new(IconName::LayoutDashboard)
+                            .small()
+                            .text_color(cx.theme().muted_foreground),
+                    )
+                    .child(div().w(px(96.)).child(Slider::new(&self.thumb)))
+                    .child(
+                        div()
+                            .text_xs()
+                            .text_color(cx.theme().muted_foreground)
+                            .child(format!("{} per row", gallery::columns(cx))),
+                    )
+            },
+        )
     }
 
     /// Centre panel: not closable, so the main view always keeps its body.
@@ -337,86 +365,50 @@ impl Panel for ViewsPanel {
 impl Render for ViewsPanel {
     fn render(&mut self, _window: &mut Window, cx: &mut Context<Self>) -> impl IntoElement {
         let this = cx.entity().downgrade();
-        v_flex().size_full().track_focus(&self.focus_handle).child(
-            div()
-                .flex_1()
-                .min_h_0()
-                .relative()
-                // The gallery needs to know how wide it is to pick a column count; nothing
-                // else measures this panel. Guarded so writing the width can't re-trigger
-                // itself into a repaint loop.
-                .child(
-                    canvas(
-                        move |bounds, _, cx| {
-                            let Some(this) = this.upgrade() else { return };
-                            this.update(cx, |this, cx| {
-                                if this.body_width != bounds.size.width {
-                                    this.body_width = bounds.size.width;
-                                    cx.notify();
-                                }
-                            });
-                        },
-                        |_, _, _, _| {},
-                    )
-                    .absolute()
-                    .size_full(),
-                )
-                // Every view draws the same table state. Erased to `AnyElement` because two
-                // chained-builder types meeting in one `match` overflows rustc's stack.
-                .child(match self.view {
-                    ViewMode::Table => self.table.clone().into_any_element(),
-                    // The size control rides above the cards rather than in `toolbar_buttons`,
-                    // which the library restricts to buttons — and it belongs to the gallery, so
-                    // it goes away with it.
-                    ViewMode::Gallery => v_flex()
-                        .size_full()
-                        .child(
-                            h_flex()
-                                .flex_none()
-                                .justify_end()
-                                .items_center()
-                                .gap_2()
-                                .px_2()
-                                .pt_1()
-                                .child(
-                                    Button::new("gallery-notes-only")
-                                        .label("Notes only")
-                                        .xsmall()
-                                        .selected(self.notes_only)
-                                        .tooltip("Show only items with notes")
-                                        .on_click(cx.listener(|this, _, _, cx| {
-                                            this.notes_only = !this.notes_only;
-                                            cx.notify();
-                                        })),
-                                )
-                                .child(div().flex_1())
-                                .child(
-                                    Icon::new(IconName::LayoutDashboard)
-                                        .small()
-                                        .text_color(cx.theme().muted_foreground),
-                                )
-                                .child(div().w(px(96.)).child(Slider::new(&self.thumb)))
-                                .child(
-                                    div()
-                                        .w(px(34.))
-                                        .text_xs()
-                                        .text_color(cx.theme().muted_foreground)
-                                        .child(format!("{}px", gallery::card_width(cx).round())),
-                                ),
+        v_flex()
+            .size_full()
+            .key_context(VIEWS_CONTEXT)
+            .track_focus(&self.focus_handle)
+            .child(
+                div()
+                    .flex_1()
+                    .min_h_0()
+                    .relative()
+                    // The gallery needs to know how wide it is to pick a column count; nothing
+                    // else measures this panel. Guarded so writing the width can't re-trigger
+                    // itself into a repaint loop.
+                    .child(
+                        canvas(
+                            move |bounds, _, cx| {
+                                let Some(this) = this.upgrade() else { return };
+                                this.update(cx, |this, cx| {
+                                    if this.body_width != bounds.size.width {
+                                        this.body_width = bounds.size.width;
+                                        cx.notify();
+                                    }
+                                });
+                            },
+                            |_, _, _, _| {},
                         )
-                        .child(div().flex_1().min_h_0().child(gallery::render(
+                        .absolute()
+                        .size_full(),
+                    )
+                    // Every view draws the same table state. Erased to `AnyElement` because two
+                    // chained-builder types meeting in one `match` overflows rustc's stack.
+                    .child(match self.view {
+                        ViewMode::Table => self.table.clone().into_any_element(),
+                        ViewMode::Gallery => gallery::render(
                             self.state.as_ref().and_then(WeakEntity::upgrade),
                             self.body_width,
-                            self.notes_only,
+                            &self.focus_handle,
                             cx,
-                        )))
-                        .into_any_element(),
-                })
-                // The clicked card's photo, over the grid of thumbnails but under nothing
-                // else — the docked panels stay put, which is the whole point of scoping it
-                // here instead of over the workspace. Escape or the ✕ puts the cards back.
-                .children(crate::viewer::viewer_in(ViewerScope::Centre, cx)),
-        )
+                        ),
+                    })
+                    // The clicked card's photo, over the grid of thumbnails but under nothing
+                    // else — the docked panels stay put, which is the whole point of scoping it
+                    // here instead of over the workspace. Escape or the ✕ puts the cards back.
+                    .children(crate::viewer::viewer_in(ViewerScope::Centre, cx)),
+            )
     }
 }
 


### PR DESCRIPTION
Implements the `SelectionStates` design from the [Tropy Gallery Design System](https://claude.ai/design/p/aa1e2688-4d0d-453e-b021-966ba29d5069) — all nine selection scenarios (`1a`–`1i`) plus the chosen gallery-notes affordance (`2c`).

**Stacked on #90** — targets `feat/editing-review`, not `main`. Merge that one first.

## What changed

qrate had a single selection *cursor*; this design is built on a *set*. That is the one foundation change, and everything else is a consumer of it.

- **`table`** — `selected_rows: BTreeSet<usize>` beside the cursor rather than a new `Selection` variant, so the ~12 exhaustive matches on `Selection` stay correct as written. `range_cells()` unions the set, which is what widens Copy, Cut, Paste and Clear to a multi-selection without any of them learning it exists. ⌘-click toggles, shift down the `#` column takes a run; shift *inside* the grid still draws the cell rectangle it always drew.
- **`details`** — a bundle reports the fields its items agree on and counts the ones they don't (`Mixed (3 values)`). Typing into either writes down the whole selection as one undo step. The preview becomes a stack of offset cards stepped through on hover, and every selected item keeps a slot — including one with no linked file.
- **`gallery`** — cards answer to the same three gestures as the grid and take the same selected fill. Page counts and note counts on the tile.
- **menu** — a menu raised on a bundle opens with what it is about. Every label carries its count; the reveal entry counts *files*, since a selection can hold rows that never matched one.
- **`notes`** — an item can carry more than one note, each recording when it was filed and by whom. `__notes` gains two nullable columns added on the next save; every note written before this reads back unchanged.

## Second pass — gallery and Details polish

- **The gallery grid is sized by cards per row, not by card width.** Cards divide the panel between them, so the grid meets both edges at any width instead of leaving a gutter that read as off-centre. The slider moved into the panel title beside the view switcher, which costs the cards no height; the count is project-scoped (`gallery_columns`).
- **The tile follows the design.** Square frame carrying its own ring, caption below it, page and note counts as scrim badges — an icon and a bare number, since "3 pages" is most of a tile at the small end.
- **A note filed on a *cell* now counts as a note on its item.** `Diagnostics::at` matches the column exactly, so `(row, None)` only ever found row-level notes: a note typed into a cell in the grid left both the gallery tile and the Details panel saying "none". `notes_in_row` takes everything on the row; the grid still marks each where it was attached, and a note's byline now says which field it hangs off.
- **The Notes sub-panel collapses to its header.** Collapsing pins the panel's size range rather than removing it from the split — removing it re-syncs the group, which rescales every panel to the container, so the fields jumped on the way out and the notes returned at whatever that rescale had left. Pinned, the dragged height comes back exactly. The pinned height includes the bottom-dock crop, or the bar lands inside the 29px a closed bottom dock covers.
- **Escape clears the selection**, replacing the bundle's Copy/Clear buttons. Bound in the grid, Details and the centre panel rather than globally, so the find bar, cell editor, popup menus and the viewer keep answering it with "close me".
- Fixes: the bundle heading no longer runs the field list past the bottom of the panel (its last row was cut in half), and the preview stack's arrows and position chip take the opaque background the rest of that overlay already uses — a ghost chevron was invisible on both a dark scan and a bright one.

## Deliberate deviations

- *"Set field for N items…"* dropped — that is what the Details panel now is; a modal would be the worse route to it.
- *"Re-check file matches"* dropped — re-resolving links is a command over the sheet, not a property of the selection.
- The destructive menu line is not red: `PopupMenuItem` has no danger variant. It is the existing "Delete N rows", correctly counted.
- *"Notes only"* and its "N of M have notes" count were built and then removed — the filter earned less than the toolbar room it cost.

## Notes for review

- Colours are read from `cx.theme()` throughout, never hardcoded. The design's tokens were themselves derived from gpui-component's default theme, so the mapping is 1:1 and dark mode is correct for free.
- `preview::page_count` is memoized by path+mtime — the gallery asks it of every visible card on every frame, and each miss was a PDFium load or a walk through a TIFF's image list.
- Rebased onto `feat/editing-review` (`9946c18`) and now fast-forward mergeable. The branch had carried a merge commit joining two patch-identical copies of the same five commits; every pair was verified by `patch-id` before the duplicate was dropped. Diffing the rebased tree against the pre-rebase state shows only the four files from #90's two newest commits — nothing of this branch's work changed.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings -A dead_code`, and `cargo test --workspace` all pass on the rebased branch. Also launched the real app against a 1893-row project: no errors or panics in the session log.

Tests cover the view-order union, filter interaction, shift-extend, mixed-field batch editing, the reveal-label arithmetic, the page-count memo, note accumulation vs. correction, a cell note counting toward its row, and the `__notes` migration from a pre-provenance schema.
